### PR TITLE
Double cpuct_visits_scale

### DIFF
--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -106,6 +106,6 @@ make_mcts_params! {
     cpuct: f32 = 0.65, 0.1, 5.0, 0.1, 0.002;
     cpuct_var_weight: f32 = 0.85, 0.0, 2.0, 0.1, 0.002;
     cpuct_var_scale: f32 = 0.2, 0.0, 2.0, 0.05, 0.002;
-    cpuct_visits_scale: i32 = 64, 1, 512, 4, 0.002;
+    cpuct_visits_scale: i32 = 32, 1, 512, 4, 0.002;
     expl_tau: f32 = 0.5, 0.1, 1.0, 0.05, 0.002;
 }


### PR DESCRIPTION
Passed STC:
https://montychess.org/tests/view/66839acd1bba54efe6ac71ec
LLR: 3.03 (-2.94,2.94) <0.00,4.00>
Total: 4128 W: 1093 L: 919 D: 2116
Ptnml(0-2): 51, 440, 935, 560, 78

Passed LTC:
https://montychess.org/tests/view/66836a3e1bba54efe6ac71e4
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 2604 W: 638 L: 484 D: 1482
Ptnml(0-2): 17, 240, 647, 368, 30

Bench: 1786121