### PR TITLE
Increase cpuct_visits_scale precision

### DIFF
--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -12,8 +12,8 @@ impl SearchHelpers {
         };
 
         // scale CPUCT as visits increase
-        let scale = params.cpuct_visits_scale() * 128;
-        cpuct *= 1.0 + (((parent.visits() + scale) / scale) as f32).ln();
+        let scale = params.cpuct_visits_scale() * 128.0;
+        cpuct *= 1.0 + ((parent.visits() as f32 + scale) / scale).ln();
 
         // scale CPUCT with variance of Q
         if parent.visits() > 1 {

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -100,7 +100,7 @@ macro_rules! make_mcts_params {
     };
 }
 
-make_mcts_params! {
+make_mcts_params! { 
     root_pst: f32 = 4.0, 1.0, 10.0, 0.4, 0.002;
     root_cpuct: f32 = 0.65, 0.1, 5.0, 0.065, 0.002;
     cpuct: f32 = 0.65, 0.1, 5.0, 0.065, 0.002;

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -11,7 +11,7 @@ impl<T> Param<T> {
     }
 }
 
-impl Param<i32> {
+/*impl Param<i32> {
     fn set(&mut self, val: i32) {
         self.val = val.clamp(self.min, self.max);
     }
@@ -29,7 +29,7 @@ impl Param<i32> {
             name, self.val, self.min, self.max, step, r,
         );
     }
-}
+}*/
 
 impl Param<f32> {
     fn set(&mut self, val: i32) {
@@ -101,11 +101,11 @@ macro_rules! make_mcts_params {
 }
 
 make_mcts_params! {
-    root_pst: f32 = 4.0, 1.0, 10.0, 0.2, 0.002;
-    root_cpuct: f32 = 0.65, 0.1, 5.0, 0.1, 0.002;
-    cpuct: f32 = 0.65, 0.1, 5.0, 0.1, 0.002;
-    cpuct_var_weight: f32 = 0.85, 0.0, 2.0, 0.1, 0.002;
-    cpuct_var_scale: f32 = 0.2, 0.0, 2.0, 0.05, 0.002;
-    cpuct_visits_scale: i32 = 64, 1, 512, 4, 0.002;
+    root_pst: f32 = 4.0, 1.0, 10.0, 0.4, 0.002;
+    root_cpuct: f32 = 0.65, 0.1, 5.0, 0.065, 0.002;
+    cpuct: f32 = 0.65, 0.1, 5.0, 0.065, 0.002;
+    cpuct_var_weight: f32 = 0.85, 0.0, 2.0, 0.085, 0.002;
+    cpuct_var_scale: f32 = 0.2, 0.0, 2.0, 0.02, 0.002;
+    cpuct_visits_scale: f32 = 32.0, 1.0, 512.0, 3.2, 0.002;
     expl_tau: f32 = 0.5, 0.1, 1.0, 0.05, 0.002;
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -297,9 +297,9 @@ fn go(
         time = Some(time.unwrap_or(u128::MAX).min(max));
     }
 
-    // 5ms move overhead
+    // 10ms move overhead
     if let Some(t) = time.as_mut() {
-        *t = t.saturating_sub(5);
+        *t = t.saturating_sub(10);
     }
 
     let abort = AtomicBool::new(false);


### PR DESCRIPTION
Changes calculation from int to float. Main motivation is to allow the setting up of spsa params optimally.

Also doubles move overhead from 5ms to 10ms (preventing possible time losses)

Passed STC:
https://montychess.org/tests/view/6683f0101bba54efe6ac7201
LLR: 2.95 (-2.94,2.94) <-3.50,0.50>
Total: 8416 W: 2102 L: 1968 D: 4346
Ptnml(0-2): 112, 1008, 1869, 1072, 147

Passed LTC:
https://montychess.org/tests/view/6683fcdbca41bb3d0a8faace
LLR: 2.95 (-2.94,2.94) <-3.50,0.50>
Total: 6054 W: 1324 L: 1200 D: 3530
Ptnml(0-2): 36, 658, 1531, 750, 52

Bench: 1997729