### PR TITLE
Scale time usage based on nodes percentage of best move

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -6,7 +6,7 @@ pub use params::MctsParams;
 
 use crate::{
     chess::Move,
-    tree::{Node, Tree, Edge},
+    tree::{Edge, Node, Tree},
     ChessState, GameState, PolicyNetwork, ValueNetwork,
 };
 
@@ -137,9 +137,12 @@ impl<'a> Searcher<'a> {
 
                     // Use less time if our best move has a large percentage of visits, and vice versa
                     let nodes_effort = self.get_best_action().visits() as f32 / nodes as f32;
-                    let best_move_visits = (2.5 - ((nodes_effort + 0.3) * 0.55).ln_1p() * 4.0).clamp(0.55, 1.50);
+                    let best_move_visits =
+                        (2.5 - ((nodes_effort + 0.3) * 0.55).ln_1p() * 4.0).clamp(0.55, 1.50);
 
-                    let total_time = (time as f32 * falling_eval * best_move_instability * best_move_visits) as u128;
+                    let total_time =
+                        (time as f32 * falling_eval * best_move_instability * best_move_visits)
+                            as u128;
                     if elapsed >= total_time {
                         break;
                     }

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -137,7 +137,7 @@ impl<'a> Searcher<'a> {
 
                     // Use less time if our best move has a large percentage of visits, and vice versa
                     let nodes_effort = self.get_best_action().visits() as f32 / nodes as f32;
-                    let best_move_visits = (2.5 - (nodes_effort * 0.6).ln_1p() * 5.0).clamp(0.45, 1.50);
+                    let best_move_visits = (2.4 - ((nodes_effort + 0.3) * 0.5).ln_1p() * 4.0).clamp(0.45, 1.50);
 
                     let total_time = (time as f32 * falling_eval * best_move_instability * best_move_visits) as u128;
                     if elapsed >= total_time {

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -137,7 +137,7 @@ impl<'a> Searcher<'a> {
 
                     // Use less time if our best move has a large percentage of visits, and vice versa
                     let nodes_effort = self.get_best_action().visits() as f32 / nodes as f32;
-                    let best_move_visits = (2.4 - ((nodes_effort + 0.3) * 0.5).ln_1p() * 4.0).clamp(0.45, 1.50);
+                    let best_move_visits = (2.5 - ((nodes_effort + 0.3) * 0.55).ln_1p() * 4.0).clamp(0.55, 1.50);
 
                     let total_time = (time as f32 * falling_eval * best_move_instability * best_move_visits) as u128;
                     if elapsed >= total_time {


### PR DESCRIPTION
Passed STC: https://montychess.org/tests/view/669203a31dbf900f9c8b56ba
LLR: 2.95 (-2.94,2.94) <0.00,4.00>
Total: 1792 W: 525 L: 359 D: 908
Ptnml(0-2): 22, 148, 410, 274, 42 

Passed LTC: https://montychess.org/tests/view/669213191dbf900f9c8b56cd
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 6000 W: 1393 L: 1224 D: 3383
Ptnml(0-2): 39, 652, 1468, 783, 58 

Bench: 2096379