### PR TITLE
New Value Network: `nn-8114cbd75a19.network`

### DIFF
--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -2,14 +2,14 @@ use crate::Board;
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-7cb08f3dcec2.network";
+pub const ValueFileDefaultName: &str = "nn-8114cbd75a19.network";
 
 const SCALE: i32 = 400;
 
 #[repr(C)]
 pub struct ValueNetwork {
-    l1: Layer<{ 768 * 4 }, 512>,
-    l2: Layer<512, 16>,
+    l1: Layer<{ 768 * 4 }, 768>,
+    l2: Layer<768, 16>,
     l3: Layer<16, 16>,
     l4: Layer<16, 16>,
     l5: Layer<16, 16>,

--- a/train/value/src/main.rs
+++ b/train/value/src/main.rs
@@ -5,7 +5,7 @@ use bullet::{
 };
 use monty::Board;
 
-const HIDDEN_SIZE: usize = 512;
+const HIDDEN_SIZE: usize = 768;
 
 fn main() {
     let mut trainer = TrainerBuilder::default()
@@ -36,7 +36,7 @@ fn main() {
         .build();
 
     let schedule = TrainingSchedule {
-        net_id: "22-07-24".to_string(),
+        net_id: "23-07-24".to_string(),
         eval_scale: 400.0,
         ft_regularisation: 0.0,
         batch_size: 16_384,


### PR DESCRIPTION
Increased L1 size to 768.

Data:
- 6695b5891dbf900f9c8b59fc
- 669449111dbf900f9c8b58e6
- 66933f591dbf900f9c8b57c3
- 669075871dbf900f9c8b5454
- 669167f81dbf900f9c8b55e3
- 669017281dbf900f9c8b53ad
- 669016bf1dbf900f9c8b53aa
- 6697116f41a4a35b6ff04c50
- 6698729441a4a35b6ff04d87
- 669a3fccd82819184c93570f
- 669b4cf2d82819184c93580a
- 669bf5cd79f789d3da83df18
- 669c85a779f789d3da83dfed

Passed STC:
LLR: 2.91 (-2.94,2.94) <0.00,4.00>
Total: 1824 W: 557 L: 392 D: 875
Ptnml(0-2): 17, 179, 386, 282, 48
https://montychess.org/tests/view/669f63240f6f1e65cfa28ab4

Passed LTC:
LLR: 2.93 (-2.94,2.94) <1.00,5.00>
Total: 1590 W: 455 L: 300 D: 835
Ptnml(0-2): 9, 132, 373, 257, 24
https://montychess.org/tests/view/669f6d360f6f1e65cfa28ac8

Bench: 2334837