### PR TITLE
New Value Network: `nn-aa12d311b50d.network`

### DIFF
--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -2,14 +2,14 @@ use crate::Board;
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-8114cbd75a19.network";
+pub const ValueFileDefaultName: &str = "nn-aa12d311b50d.network";
 
 const SCALE: i32 = 400;
 
 #[repr(C)]
 pub struct ValueNetwork {
-    l1: Layer<{ 768 * 4 }, 768>,
-    l2: Layer<768, 16>,
+    l1: Layer<{ 768 * 4 }, 1024>,
+    l2: Layer<1024, 16>,
     l3: Layer<16, 16>,
     l4: Layer<16, 16>,
     l5: Layer<16, 16>,

--- a/train/value/src/main.rs
+++ b/train/value/src/main.rs
@@ -5,7 +5,7 @@ use bullet::{
 };
 use monty::Board;
 
-const HIDDEN_SIZE: usize = 768;
+const HIDDEN_SIZE: usize = 1024;
 
 fn main() {
     let mut trainer = TrainerBuilder::default()
@@ -36,7 +36,7 @@ fn main() {
         .build();
 
     let schedule = TrainingSchedule {
-        net_id: "23-07-24".to_string(),
+        net_id: "02-08-24".to_string(),
         eval_scale: 400.0,
         ft_regularisation: 0.0,
         batch_size: 16_384,
@@ -55,7 +55,7 @@ fn main() {
 
     let settings = LocalSettings {
         threads: 4,
-        data_file_paths: vec!["../monty-data/22-07-24.data"],
+        data_file_paths: vec!["../monty-data/02-08-24.data"],
         output_directory: "checkpoints",
     };
 


### PR DESCRIPTION
Increased L1 to 1024.

Data:
- 6695b5891dbf900f9c8b59fc
- 669449111dbf900f9c8b58e6
- 66933f591dbf900f9c8b57c3
- 669075871dbf900f9c8b5454
- 669167f81dbf900f9c8b55e3
- 669017281dbf900f9c8b53ad
- 669016bf1dbf900f9c8b53aa
- 6697116f41a4a35b6ff04c50
- 6698729441a4a35b6ff04d87
- 669a3fccd82819184c93570f
- 669b4cf2d82819184c93580a
- 669bf5cd79f789d3da83df18
- 669c85a779f789d3da83dfed
- 66a2c8c20f6f1e65cfa28e47
- 66a6c2d20f6f1e65cfa29466

Passed STC:
LLR: 2.98 (-2.94,2.94) <0.00,4.00>
Total: 1280 W: 434 L: 257 D: 589
Ptnml(0-2): 11, 118, 233, 239, 39
https://montychess.org/tests/view/66ac9b930f6f1e65cfa29fa8

Passed LTC:
LLR: 2.95 (-2.94,2.94) <1.00,5.00>
Total: 1452 W: 413 L: 257 D: 782
Ptnml(0-2): 7, 119, 333, 245, 22
https://montychess.org/tests/view/66acac930f6f1e65cfa2a07b

Bench: 2413598