### PR TITLE
SMP Improvements

### DIFF
--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -118,7 +118,7 @@ impl<'a> DatagenThread<'a> {
             }
 
             let abort = AtomicBool::new(false);
-            tree.try_use_subtree(&position, &None);
+            tree.try_use_subtree(&position, &None, 1);
             let searcher =
                 Searcher::new(position.clone(), &tree, &self.params, policy, value, &abort);
 

--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -107,7 +107,7 @@ impl<'a> DatagenThread<'a> {
         let mut records = Vec::new();
         let mut result = 0.5;
 
-        let mut tree = Tree::new_mb(8);
+        let mut tree = Tree::new_mb(8, 1);
 
         let mut game = Binpack::new(position.clone());
 
@@ -164,7 +164,7 @@ impl<'a> DatagenThread<'a> {
                 }
             }
 
-            tree.clear();
+            tree.clear(1);
         }
 
         if let Some(out) = pout {

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -253,7 +253,7 @@ impl<'a> Searcher<'a> {
                 }
             });
 
-            self.tree.flip(true);
+            self.tree.flip(true, threads);
         }
 
         self.abort.store(true, Ordering::Relaxed);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -46,8 +46,8 @@ impl Tree {
     fn new(tree_cap: usize, hash_cap: usize, threads: usize) -> Self {
         Self {
             tree: [
-                TreeHalf::new(tree_cap / 2, false),
-                TreeHalf::new(tree_cap / 2, true),
+                TreeHalf::new(tree_cap / 2, false, threads),
+                TreeHalf::new(tree_cap / 2, true, threads),
             ],
             half: AtomicBool::new(false),
             hash: HashTable::new(hash_cap / 4, threads),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -227,7 +227,12 @@ impl Tree {
         }
     }
 
-    pub fn try_use_subtree(&mut self, root: &ChessState, prev_board: &Option<ChessState>, threads: usize) {
+    pub fn try_use_subtree(
+        &mut self,
+        root: &ChessState,
+        prev_board: &Option<ChessState>,
+        threads: usize,
+    ) {
         let t = Instant::now();
 
         if self.is_empty() {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -82,11 +82,11 @@ impl Tree {
         std::mem::swap(f, t);
     }
 
-    pub fn flip(&self, copy_across: bool) {
+    pub fn flip(&self, copy_across: bool, threads: usize) {
         let old_root_ptr = self.root_node();
 
         let old = usize::from(self.half.fetch_xor(true, Ordering::Relaxed));
-        self.tree[old].clear_ptrs();
+        self.tree[old].clear_ptrs(threads);
         self.tree[old ^ 1].clear();
 
         if copy_across {
@@ -227,7 +227,7 @@ impl Tree {
         }
     }
 
-    pub fn try_use_subtree(&mut self, root: &ChessState, prev_board: &Option<ChessState>) {
+    pub fn try_use_subtree(&mut self, root: &ChessState, prev_board: &Option<ChessState>, threads: usize) {
         let t = Instant::now();
 
         if self.is_empty() {
@@ -262,7 +262,7 @@ impl Tree {
         if !found {
             println!("info string no subtree found");
             self.clear_halves();
-            self.flip(false);
+            self.flip(false, threads);
             self.push_new(GameState::Ongoing).unwrap();
         }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -38,19 +38,19 @@ impl std::ops::Index<NodePtr> for Tree {
 }
 
 impl Tree {
-    pub fn new_mb(mb: usize) -> Self {
+    pub fn new_mb(mb: usize, threads: usize) -> Self {
         let bytes = mb * 1024 * 1024;
-        Self::new(bytes / (48 + 20 * 20), bytes / 48 / 16)
+        Self::new(bytes / (48 + 20 * 20), bytes / 48 / 16, threads)
     }
 
-    fn new(tree_cap: usize, hash_cap: usize) -> Self {
+    fn new(tree_cap: usize, hash_cap: usize, threads: usize) -> Self {
         Self {
             tree: [
                 TreeHalf::new(tree_cap / 2, false),
                 TreeHalf::new(tree_cap / 2, true),
             ],
             half: AtomicBool::new(false),
-            hash: HashTable::new(hash_cap / 4),
+            hash: HashTable::new(hash_cap / 4, threads),
             root_stats: ActionStats::default(),
         }
     }
@@ -187,9 +187,9 @@ impl Tree {
         self.root_stats.clear();
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self, threads: usize) {
         self.clear_halves();
-        self.hash.clear();
+        self.hash.clear(threads);
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/tree/half.rs
+++ b/src/tree/half.rs
@@ -48,14 +48,35 @@ impl TreeHalf {
         self.used.store(0, Ordering::Relaxed);
     }
 
-    pub fn clear_ptrs(&self) {
-        for node in &self.nodes {
+    pub fn clear_ptrs(&self, threads: usize) {
+        if threads == 1 {
+            Self::clear_ptrs_single_threaded(self.half, &self.nodes);
+        } else {
+            self.clear_ptrs_multi_threaded(threads);
+        }
+    }
+
+    fn clear_ptrs_single_threaded(half: bool, nodes: &[Node]) {
+        for node in nodes {
             for action in &mut *node.actions_mut() {
-                if action.ptr().half() != self.half {
+                if action.ptr().half() != half {
                     action.set_ptr(NodePtr::NULL);
                 }
             }
         }
+    }
+
+    fn clear_ptrs_multi_threaded(&self, threads: usize) {
+        std::thread::scope(|s| {
+            let chunk_size = (self.nodes.len() + threads - 1) / threads;
+
+            s.spawn(move || {
+                for node_chunk in self.nodes.chunks(chunk_size) {
+                    Self::clear_ptrs_single_threaded(self.half, node_chunk)
+                }
+            });
+
+        });
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/tree/half.rs
+++ b/src/tree/half.rs
@@ -92,7 +92,6 @@ impl TreeHalf {
                     Self::clear_ptrs_single_threaded(self.half, node_chunk)
                 }
             });
-
         });
     }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -24,7 +24,7 @@ impl Uci {
         let mut pos = ChessState::default();
         let mut root_game_ply = 0;
         let mut params = MctsParams::default();
-        let mut tree = Tree::new_mb(64);
+        let mut tree = Tree::new_mb(64, 1);
         let mut report_moves = false;
         let mut threads = 1;
 
@@ -125,7 +125,7 @@ impl Uci {
                 "ucinewgame" => {
                     prev = None;
                     root_game_ply = 0;
-                    tree.clear();
+                    tree.clear(threads);
                 }
                 _ => {}
             }
@@ -144,7 +144,7 @@ impl Uci {
             max_nodes: 1_000_000,
         };
 
-        let mut tree = Tree::new_mb(32);
+        let mut tree = Tree::new_mb(32, 1);
 
         for fen in bench_fens {
             let abort = AtomicBool::new(false);
@@ -154,7 +154,7 @@ impl Uci {
             let timer = Instant::now();
             searcher.search(1, limits, false, &mut total_nodes);
             time += timer.elapsed().as_secs_f32();
-            tree.clear();
+            tree.clear(1);
         }
 
         println!(
@@ -203,7 +203,7 @@ fn setoption(
     };
 
     if name == "Hash" {
-        *tree = Tree::new_mb(val as usize);
+        *tree = Tree::new_mb(val as usize, *threads);
     } else {
         params.set(name, val);
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -149,7 +149,7 @@ impl Uci {
         for fen in bench_fens {
             let abort = AtomicBool::new(false);
             let pos = ChessState::from_fen(fen);
-            tree.try_use_subtree(&pos, &None);
+            tree.try_use_subtree(&pos, &None, 1);
             let searcher = Searcher::new(pos, &tree, params, policy, value, &abort);
             let timer = Instant::now();
             searcher.search(1, limits, false, &mut total_nodes);
@@ -320,7 +320,7 @@ fn go(
 
     let abort = AtomicBool::new(false);
 
-    tree.try_use_subtree(pos, &prev);
+    tree.try_use_subtree(pos, &prev, threads);
 
     let limits = Limits {
         max_time,


### PR DESCRIPTION
Non-functional speedup when running with >1 thread:
- Threaded tree initialisation
- Threaded hash table clearing
- Threaded tree flipping

Speedups aren't noticeable at montytest conditions, necessary for TCEC/CCC.

Passed STC Non-Regression:
LLR: 2.92 (-2.94,2.94) <-3.50,0.50>
Total: 12928 W: 2826 L: 2718 D: 7384
Ptnml(0-2): 95, 1476, 3240, 1532, 121
https://montychess.org/tests/view/66b2956e0f6f1e65cfa2ccec

Passed STC SMP Non-Regression:
LLR: 2.93 (-2.94,2.94) <-3.50,0.50>
Total: 16896 W: 4446 L: 4337 D: 8113
Ptnml(0-2): 237, 2009, 3878, 2056, 268
https://montychess.org/tests/view/66b296300f6f1e65cfa2ccf9

Bench: 1954267