### PR TITLE
Improve Tree Reuse

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -248,7 +248,7 @@ impl<'a> Searcher<'a> {
                         &mut previous_score,
                         #[cfg(not(feature = "uci-minimal"))]
                         uci_output,
-                    )
+                    );
                 });
 
                 for _ in 0..threads - 1 {


### PR DESCRIPTION
Avoids needless tree flip before stopping search.

Previously, you could end a search with only, say, 5% of the tree in the active half, and the other 95% in the inactive half. The tree would then be flipped and that 95% of the tree would be lost.

Passed STC:
LLR: 2.93 (-2.94,2.94) <0.00,4.00>
Total: 3968 W: 922 L: 768 D: 2278
Ptnml(0-2): 35, 378, 1019, 502, 50
https://montychess.org/tests/view/66b336533ae9310e136dac59

Passed LTC:
LLR: 2.96 (-2.94,2.94) <1.00,5.00>
Total: 3390 W: 745 L: 602 D: 2043
Ptnml(0-2): 7, 311, 933, 420, 24
https://montychess.org/tests/view/66b33fac3ae9310e136dac8e

Bench: 1954267