### PR TITLE
New Value Network: `nn-ac891f8a5994.network`

### DIFF
--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -2,14 +2,14 @@ use crate::Board;
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-aa12d311b50d.network";
+pub const ValueFileDefaultName: &str = "nn-ac891f8a5994.network";
 
 const SCALE: i32 = 400;
 
 #[repr(C)]
 pub struct ValueNetwork {
-    l1: Layer<{ 768 * 4 }, 1024>,
-    l2: Layer<1024, 16>,
+    l1: Layer<{ 768 * 4 }, 2048>,
+    l2: Layer<2048, 16>,
     l3: Layer<16, 16>,
     l4: Layer<16, 16>,
     l5: Layer<16, 16>,

--- a/train/value/src/main.rs
+++ b/train/value/src/main.rs
@@ -5,7 +5,7 @@ use bullet::{
 };
 use monty::Board;
 
-const HIDDEN_SIZE: usize = 1024;
+const HIDDEN_SIZE: usize = 2048;
 
 fn main() {
     let mut trainer = TrainerBuilder::default()
@@ -36,18 +36,18 @@ fn main() {
         .build();
 
     let schedule = TrainingSchedule {
-        net_id: "02-08-24".to_string(),
+        net_id: "11-08-24".to_string(),
         eval_scale: 400.0,
         ft_regularisation: 0.0,
         batch_size: 16_384,
         batches_per_superbatch: 6104,
         start_superbatch: 1,
-        end_superbatch: 320,
+        end_superbatch: 640,
         wdl_scheduler: WdlScheduler::Constant { value: 0.5 },
         lr_scheduler: LrScheduler::Step {
             start: 0.001,
             gamma: 0.1,
-            step: 120,
+            step: 240,
         },
         loss_function: Loss::SigmoidMSE,
         save_rate: 10,
@@ -55,7 +55,7 @@ fn main() {
 
     let settings = LocalSettings {
         threads: 4,
-        data_file_paths: vec!["../monty-data/02-08-24.data"],
+        data_file_paths: vec!["../monty-data/11-08-24.data"],
         output_directory: "checkpoints",
     };
 


### PR DESCRIPTION
Increased L1 from 1024 to 2048. Also doubled training time from 320 to 640 superbatches.

Data used:
- 66a2c8c20f6f1e65cfa28e47
- 66a6c2d20f6f1e65cfa29466
- 66ac3c0a0f6f1e65cfa29bb8
- 66acb00f0f6f1e65cfa2a097
- 66ad85fc0f6f1e65cfa2a97a
- 66b053720f6f1e65cfa2b65c
- 66b1a5e70f6f1e65cfa2c1c6
- 66b281ba0f6f1e65cfa2cbf6
- 66b281d40f6f1e65cfa2cbf9
- 66b3f1a23ae9310e136db0a4
- 66b455273ae9310e136db441

Passed STC:
https://montychess.org/tests/view/66b7bcd23ae9310e136dd05e
LLR: 2.95 (-2.94,2.94) <0.00,4.00>
Total: 1216 W: 388 L: 224 D: 604
Ptnml(0-2): 6, 104, 252, 212, 34

Passed LTC:
https://montychess.org/tests/view/66b7c38c3ae9310e136dd083
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 1182 W: 363 L: 201 D: 618
Ptnml(0-2): 7, 81, 270, 209, 24

Bench: 1336944