### PR TITLE
Redefine nodes count

### DIFF
--- a/src/chess.rs
+++ b/src/chess.rs
@@ -78,7 +78,7 @@ impl Default for ChessState {
 
 impl ChessState {
     pub const STARTPOS: &'static str = STARTPOS;
-    pub const BENCH_DEPTH: usize = 7;
+    pub const BENCH_DEPTH: usize = 6;
 
     pub fn bbs(&self) -> [u64; 8] {
         self.board.bbs()

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -260,8 +260,8 @@ impl<'a> Searcher<'a> {
         let total_nodes = AtomicUsize::new(0);
         let total_mcts_nodes = AtomicUsize::new(0);
         let total_depth = AtomicUsize::new(0);
-        let mut avg_depth = AtomicUsize::new(0);
-        let mut main_mcts_nodes = AtomicUsize::new(0);
+        let avg_depth = AtomicUsize::new(0);
+        let main_mcts_nodes = AtomicUsize::new(0);
 
         let mut best_move = Move::NULL;
         let mut best_move_changes = 0;
@@ -277,8 +277,8 @@ impl<'a> Searcher<'a> {
                         &total_nodes,
                         &total_mcts_nodes,
                         &total_depth,
-                        &mut avg_depth,
-                        &mut main_mcts_nodes,
+                        &avg_depth,
+                        &main_mcts_nodes,
                         &mut best_move,
                         &mut best_move_changes,
                         &mut previous_score,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -83,6 +83,15 @@ impl Uci {
 
                     prev = Some(pos.clone());
                 }
+                "bench" => {
+                    let depth = if let Some(d) = commands.get(1) {
+                        d.parse().unwrap_or(ChessState::BENCH_DEPTH)
+                    } else {
+                        ChessState::BENCH_DEPTH
+                    };
+
+                    Uci::bench(depth, policy, value, &params);
+                }
                 "perft" => run_perft(&commands, &pos),
                 "quit" => std::process::exit(0),
                 "eval" => {


### PR DESCRIPTION
Previously, a node was one complete playout from the root position. Now, we redefine nodes count to the number of times `perform_one_iteration()` is called, i.e. for every position we consider. The previous definition has been renamed to "iters" as a more unambiguous term.

The benefit of this is a much more consistent NPS value, as opposed to the previous version where NPS would greatly fluctuate between different patches.

This patch also includes all search threads in the total nodes count calculation and output, not just the main thread. 

It also makes bench as well as move overhead a UCI option and increases it from 20ms to 40ms to eliminate time losses on STC SMP tests.

Bench depth was also decreased from 7 to 6 to reduce the total time a bench takes.

Passed non-regression STC: https://montychess.org/tests/view/66ba5f9d3ae9310e136de28e
LLR: 3.05 (-2.94,2.94) <-3.50,0.50>
Total: 77896 W: 18486 L: 18528 D: 40882
Ptnml(0-2): 1173, 8945, 18710, 8991, 1129 

Passed non-regression STC SMP: https://montychess.org/tests/view/66ba6ff93ae9310e136de30e
LLR: 2.97 (-2.94,2.94) <-3.50,0.50>
Total: 30404 W: 7246 L: 7172 D: 15986
Ptnml(0-2): 434, 3388, 7475, 3480, 425 

Bench: 2093550