### PR TITLE
New Value Network: `nn-2eeff9457b79.network`

### DIFF
--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -2,7 +2,7 @@ use crate::Board;
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-ac891f8a5994.network";
+pub const ValueFileDefaultName: &str = "nn-2eeff9457b79.network";
 
 const SCALE: i32 = 400;
 

--- a/train/value/src/main.rs
+++ b/train/value/src/main.rs
@@ -36,26 +36,26 @@ fn main() {
         .build();
 
     let schedule = TrainingSchedule {
-        net_id: "11-08-24".to_string(),
+        net_id: "12-08-24".to_string(),
         eval_scale: 400.0,
         ft_regularisation: 0.0,
         batch_size: 16_384,
         batches_per_superbatch: 6104,
         start_superbatch: 1,
-        end_superbatch: 640,
+        end_superbatch: 1200,
         wdl_scheduler: WdlScheduler::Constant { value: 0.5 },
         lr_scheduler: LrScheduler::Step {
             start: 0.001,
             gamma: 0.1,
-            step: 240,
+            step: 300,
         },
         loss_function: Loss::SigmoidMSE,
         save_rate: 10,
     };
 
     let settings = LocalSettings {
-        threads: 4,
-        data_file_paths: vec!["../monty-data/11-08-24.data"],
+        threads: 8,
+        data_file_paths: vec!["../monty-data/12-08-24.data"],
         output_directory: "checkpoints",
     };
 


### PR DESCRIPTION
Increased training time from 640 to 1200 superbatches.
The majority of the extra superbatches are in the previous final LR and also in a new LR drop.

Passed STC:
https://montychess.org/tests/view/66bca6eea3c9324987f1a267
LLR: 3.08 (-2.94,2.94) <0.00,4.00>
Total: 5728 W: 1568 L: 1379 D: 2781
Ptnml(0-2): 87, 639, 1280, 714, 144

Passed LTC:
https://montychess.org/tests/view/66bcacc6a3c9324987f1a29f
LLR: 2.93 (-2.94,2.94) <1.00,5.00>
Total: 4110 W: 1019 L: 855 D: 2236
Ptnml(0-2): 27, 444, 975, 556, 53

Bench: 2231884