### PR TITLE
Improve Virtual Loss Implementation

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -371,7 +371,7 @@ impl<'a> Searcher<'a> {
 
         self.tree.get_best_child_by_key(ptr, |action| {
             let mut q = SearchHelpers::get_action_value(action, fpu);
-            
+
             if !action.ptr().is_null() {
                 q -= self.params.virtual_loss() * f32::from(self.tree[action.ptr()].threads());
             }

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -370,11 +370,11 @@ impl<'a> Searcher<'a> {
         let expl = cpuct * expl_scale;
 
         self.tree.get_best_child_by_key(ptr, |action| {
-            let q = if !action.ptr().is_null() && self.tree[action.ptr()].threads() > 0 {
-                0.0
-            } else {
-                SearchHelpers::get_action_value(action, fpu)
-            };
+            let mut q = SearchHelpers::get_action_value(action, fpu);
+            
+            if !action.ptr().is_null() {
+                q -= self.params.virtual_loss() * f32::from(self.tree[action.ptr()].threads());
+            }
 
             let u = expl * action.policy() / (1 + action.visits()) as f32;
 

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -130,6 +130,7 @@ macro_rules! make_mcts_params {
 }
 
 make_mcts_params! {
+    virtual_loss: f32 = 0.5, 0.0, 1.0, 0.01, 0.002;
     root_pst: f32 = 3.64, 1.0, 10.0, 0.4, 0.002;
     root_cpuct: f32 = 0.314, 0.1, 5.0, 0.065, 0.002;
     cpuct: f32 = 0.314, 0.1, 5.0, 0.065, 0.002;


### PR DESCRIPTION
Rather than setting Q to 0 in selection for a node if >0 threads already are on a path containing it, now subtract a (tunable) fixed value per thread.

Non-funtional on single thread.

Passed STC SMP:
LLR: 2.98 (-2.94,2.94) <0.00,4.00>
Total: 1520 W: 689 L: 473 D: 358
Ptnml(0-2): 55, 91, 322, 167, 125
https://montychess.org/tests/view/66cb94247f3228f03eb73526

Passed LTC SMP:
LLR: 2.97 (-2.94,2.94) <1.00,5.00>
Total: 1172 W: 517 L: 323 D: 332
Ptnml(0-2): 15, 91, 255, 135, 90
https://montychess.org/tests/view/66cbcd865940a4e06cfcba6b

Bench: 1317423