### PR TITLE
True Virtual Loss

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -373,7 +373,12 @@ impl<'a> Searcher<'a> {
             let mut q = SearchHelpers::get_action_value(action, fpu);
 
             if !action.ptr().is_null() {
-                q -= self.params.virtual_loss() * f32::from(self.tree[action.ptr()].threads());
+                let threads = f64::from(self.tree[action.ptr()].threads());
+                if threads > 0.0 {
+                    let visits = f64::from(action.visits());
+                    let q2 = f64::from(q) * visits / (visits + threads);
+                    q = q2 as f32;
+                }
             }
 
             let u = expl * action.policy() / (1 + action.visits()) as f32;

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -130,7 +130,6 @@ macro_rules! make_mcts_params {
 }
 
 make_mcts_params! {
-    virtual_loss: f32 = 0.5, 0.0, 1.0, 0.01, 0.002;
     root_pst: f32 = 3.64, 1.0, 10.0, 0.4, 0.002;
     root_cpuct: f32 = 0.314, 0.1, 5.0, 0.065, 0.002;
     cpuct: f32 = 0.314, 0.1, 5.0, 0.065, 0.002;


### PR DESCRIPTION
Real virtual loss, counting the individual *playout* as a loss, not the whole node.
Thanks to Cosmo for pointing out.

Non-funtional on single thread.

Passed STC SMP:
LLR: 2.96 (-2.94,2.94) <0.00,4.00>
Total: 520 W: 335 L: 54 D: 131
Ptnml(0-2): 6, 7, 51, 92, 104
https://montychess.org/tests/view/66ccf7d15940a4e06cfcd2dc

Passed LTC SMP:
LLR: 2.95 (-2.94,2.94) <1.00,5.00>
Total: 524 W: 293 L: 34 D: 197
Ptnml(0-2): 0, 8, 53, 135, 66
https://montychess.org/tests/view/66cd02065940a4e06cfcd2f6

Co-Authored-By: Cosmo @cosmobobak
Bench: 1317423