### PR TITLE
Quantise L2 in Value Network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ panic = 'abort'
 strip = true
 lto = true
 codegen-units = 1
-overflow-checks = true
 
 [features]
 embed = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ panic = 'abort'
 strip = true
 lto = true
 codegen-units = 1
+overflow-checks = true
 
 [features]
 embed = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,10 @@ pub unsafe fn read_into_struct_unchecked<T>(path: &str) -> Box<T> {
 
     let size = std::mem::size_of::<T>();
 
+    let file_size = f.metadata().unwrap().len();
+
+    assert_eq!(file_size as usize, size);
+
     unsafe {
         let slice = std::slice::from_raw_parts_mut(x.as_mut() as *mut T as *mut u8, size);
         f.read_exact(slice).unwrap();

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -6,5 +6,3 @@ mod value;
 
 pub use policy::{PolicyFileDefaultName, PolicyNetwork, UnquantisedPolicyNetwork};
 pub use value::{UnquantisedValueNetwork, ValueFileDefaultName, ValueNetwork};
-
-const QA: i16 = 512;

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -21,7 +21,7 @@ impl<T: AddAssign<T> + Copy + Mul<T, Output = T>, const N: usize> Accumulator<T,
 }
 
 impl<const N: usize> Accumulator<i16, N> {
-    pub fn add_multi(&mut self, adds: &[usize], weights: &[Self]) {
+    pub fn add_multi(&mut self, adds: &[usize], weights: &[Accumulator<i8, N>]) {
         const REGS: usize = 8;
         const PER: usize = REGS * 16;
 
@@ -38,7 +38,7 @@ impl<const N: usize> Accumulator<i16, N> {
                 let this_weight = &weights[add];
 
                 for (j, reg) in regs.iter_mut().enumerate() {
-                    *reg += this_weight.0[offset + j];
+                    *reg += i16::from(this_weight.0[offset + j]);
                 }
             }
 
@@ -60,7 +60,7 @@ impl<const N: usize> Accumulator<f32, N> {
         res
     }
 
-    pub fn quantise(&self, qa: i16) -> Accumulator<i16, N> {
+    pub fn quantise_i16(&self, qa: i16) -> Accumulator<i16, N> {
         let mut res = Accumulator([0; N]);
 
         for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {
@@ -69,6 +69,20 @@ impl<const N: usize> Accumulator<f32, N> {
             }
 
             *i = (j * f32::from(qa)) as i16;
+        }
+
+        res
+    }
+
+    pub fn quantise_i8(&self, qa: i8) -> Accumulator<i8, N> {
+        let mut res = Accumulator([0; N]);
+
+        for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {
+            if j > 1.98 {
+                println!("{j}")
+            }
+
+            *i = (j * f32::from(qa)) as i8;
         }
 
         res

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -20,6 +20,14 @@ impl<T: AddAssign<T> + Copy + Mul<T, Output = T>, const N: usize> Accumulator<T,
     }
 }
 
+impl<T: AddAssign<T> + Copy + Mul<T, Output = T> + From<i16>, const N: usize> Accumulator<T, N> {
+    pub fn madd_i16(&mut self, mul: T, other: &Accumulator<i16, N>) {
+        for (i, &j) in self.0.iter_mut().zip(other.0.iter()) {
+            *i += mul * T::from(j);
+        }
+    }
+}
+
 impl<const N: usize> Accumulator<i16, N> {
     pub fn add_multi(&mut self, adds: &[usize], weights: &[Self]) {
         const REGS: usize = 8;
@@ -75,11 +83,5 @@ impl<const N: usize> Accumulator<f32, N> {
         }
 
         res
-    }
-
-    pub fn madd_i16(&mut self, mul: f32, other: &Accumulator<i16, N>) {
-        for (i, &j) in self.0.iter_mut().zip(other.0.iter()) {
-            *i += mul * f32::from(j);
-        }
     }
 }

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -68,12 +68,12 @@ impl<const N: usize> Accumulator<f32, N> {
         res
     }
 
-    pub fn quantise_i16(&self, qa: i16) -> Accumulator<i16, N> {
+    pub fn quantise_i16(&self, qa: i16, warn_limit: f32) -> Accumulator<i16, N> {
         let mut res = Accumulator([0; N]);
 
         for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {
-            if j > 1.98 {
-                println!("{j}")
+            if j.abs() > warn_limit {
+                println!("WARNING: {j} > {warn_limit}")
             }
 
             let unq = j * f32::from(qa);

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -68,7 +68,10 @@ impl<const N: usize> Accumulator<f32, N> {
                 println!("{j}")
             }
 
-            *i = (j * f32::from(qa)) as i16;
+            let unq = j * f32::from(qa);
+            *i = unq as i16;
+
+            assert_eq!(unq.trunc(), f32::from(*i));
         }
 
         res
@@ -82,7 +85,10 @@ impl<const N: usize> Accumulator<f32, N> {
                 println!("{j}")
             }
 
-            *i = (j * f32::from(qa)) as i8;
+            let unq = j * f32::from(qa);
+            *i = unq as i8;
+
+            assert_eq!(unq.trunc(), f32::from(*i));
         }
 
         res

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -77,7 +77,7 @@ impl<const N: usize> Accumulator<f32, N> {
         res
     }
 
-    pub fn quantise_i8(&self, qa: i8) -> Accumulator<i8, N> {
+    pub fn quantise_i8(&self, qa: i16) -> Accumulator<i8, N> {
         let mut res = Accumulator([0; N]);
 
         for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -81,11 +81,11 @@ impl<const N: usize> Accumulator<f32, N> {
         let mut res = Accumulator([0; N]);
 
         for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {
-            if j.abs() > 1.16 {
+            if j.abs() > 0.99 {
                 println!("{j}")
             }
 
-            let unq = j.clamp(-1.16, 1.16) * f32::from(qa);
+            let unq = j * f32::from(qa);
             *i = unq as i8;
 
             assert_eq!(unq.trunc(), f32::from(*i));

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -21,7 +21,7 @@ impl<T: AddAssign<T> + Copy + Mul<T, Output = T>, const N: usize> Accumulator<T,
 }
 
 impl<const N: usize> Accumulator<i16, N> {
-    pub fn add_multi(&mut self, adds: &[usize], weights: &[Accumulator<i8, N>]) {
+    pub fn add_multi(&mut self, adds: &[usize], weights: &[Self]) {
         const REGS: usize = 8;
         const PER: usize = REGS * 16;
 
@@ -38,7 +38,7 @@ impl<const N: usize> Accumulator<i16, N> {
                 let this_weight = &weights[add];
 
                 for (j, reg) in regs.iter_mut().enumerate() {
-                    *reg += i16::from(this_weight.0[offset + j]);
+                    *reg += this_weight.0[offset + j];
                 }
             }
 
@@ -77,20 +77,9 @@ impl<const N: usize> Accumulator<f32, N> {
         res
     }
 
-    pub fn quantise_i8(&self, qa: i16) -> Accumulator<i8, N> {
-        let mut res = Accumulator([0; N]);
-
-        for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {
-            if j.abs() > 0.99 {
-                println!("{j}")
-            }
-
-            let unq = j * f32::from(qa);
-            *i = unq as i8;
-
-            assert_eq!(unq.trunc(), f32::from(*i));
+    pub fn madd_i16(&mut self, mul: f32, other: &Accumulator<i16, N>) {
+        for (i, &j) in self.0.iter_mut().zip(other.0.iter()) {
+            *i += mul * f32::from(j);
         }
-
-        res
     }
 }

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -81,11 +81,11 @@ impl<const N: usize> Accumulator<f32, N> {
         let mut res = Accumulator([0; N]);
 
         for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {
-            if j > 1.98 {
+            if j.abs() > 1.16 {
                 println!("{j}")
             }
 
-            let unq = j * f32::from(qa);
+            let unq = j.clamp(-1.16, 1.16) * f32::from(qa);
             *i = unq as i8;
 
             assert_eq!(unq.trunc(), f32::from(*i));

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -80,7 +80,12 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
         res
     }
 
-    pub fn quantise_transpose_into_i16(&self, dest: &mut TransposedLayer<i16, M, N>, qa: i16, warn_limit: f32) {
+    pub fn quantise_transpose_into_i16(
+        &self,
+        dest: &mut TransposedLayer<i16, M, N>,
+        qa: i16,
+        warn_limit: f32,
+    ) {
         let mut untrans = [Accumulator([0; N]); M];
 
         for (acc_i, acc_j) in untrans.iter_mut().zip(self.weights.iter()) {

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -108,10 +108,12 @@ impl<const M: usize, const N: usize> TransposedLayer<i16, M, N> {
         &self,
         inputs: &Accumulator<i16, M>,
     ) -> Accumulator<f32, N> {
+        const FACTOR: i16 = 16;
+
         let mut act = [0; M];
 
         for (a, &i) in act.iter_mut().zip(inputs.0.iter()) {
-            *a = (i32::from(i).clamp(0, i32::from(QA)).pow(2) / i32::from(QA)) as i16;
+            *a = (i32::from(i).clamp(0, i32::from(QA)).pow(2) / i32::from(QA / FACTOR)) as i16;
         }
 
         let mut fwd = [0; N];
@@ -125,7 +127,7 @@ impl<const M: usize, const N: usize> TransposedLayer<i16, M, N> {
         let mut res = [0.0; N];
 
         for (r, (&f, &b)) in res.iter_mut().zip(fwd.iter().zip(self.biases.0.iter())) {
-            *r = (f as f32 / f32::from(QA) + f32::from(b)) / f32::from(QA);
+            *r = (f as f32 / f32::from(QA * FACTOR) + f32::from(b)) / f32::from(QA);
         }
 
         Accumulator(res)

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -104,11 +104,11 @@ pub struct TransposedLayer<T: Copy, const M: usize, const N: usize> {
 }
 
 impl<const M: usize, const N: usize> TransposedLayer<i16, M, N> {
-    pub fn forward_from_i16<T: Activation, const QA: i16>(
+    pub fn forward_from_i16<T: Activation, const QA: i16, const QB: i16>(
         &self,
         inputs: &Accumulator<i16, M>,
     ) -> Accumulator<f32, N> {
-        const FACTOR: i16 = 16;
+        const FACTOR: i16 = 32;
 
         let mut act = [0; M];
 
@@ -127,7 +127,7 @@ impl<const M: usize, const N: usize> TransposedLayer<i16, M, N> {
         let mut res = [0.0; N];
 
         for (r, (&f, &b)) in res.iter_mut().zip(fwd.iter().zip(self.biases.0.iter())) {
-            *r = (f as f32 / f32::from(QA * FACTOR) + f32::from(b)) / f32::from(QA);
+            *r = (f as f32 / f32::from(QA * FACTOR) + f32::from(b)) / f32::from(QB);
         }
 
         Accumulator(res)

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -33,33 +33,6 @@ impl<const M: usize, const N: usize> Layer<i16, M, N> {
 
         out
     }
-
-    pub fn forward_from_i16<T: Activation, const QA: i16>(
-        &self,
-        inputs: &Accumulator<i16, M>,
-    ) -> Accumulator<f32, N> {
-        let mut act = [0; M];
-
-        for (a, &i) in act.iter_mut().zip(inputs.0.iter()) {
-            *a = (i32::from(i).clamp(0, i32::from(QA)).pow(2) / i32::from(QA)) as i16;
-        }
-
-        let mut fwd = [0; N];
-
-        for i in 0..N {
-            for j in 0..M {
-                fwd[i] += i32::from(act[j]) * i32::from(self.weights[j].0[i]);
-            }
-        }
-
-        let mut res = [0.0; N];
-
-        for (r, (&f, &b)) in res.iter_mut().zip(fwd.iter().zip(self.biases.0.iter())) {
-            *r = (f as f32 / f32::from(QA) + f32::from(b)) / f32::from(QA);
-        }
-
-        Accumulator(res)
-    }
 }
 
 impl<const M: usize, const N: usize> Layer<f32, M, N> {
@@ -105,5 +78,56 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
         self.quantise_into_i16(&mut res, qa);
 
         res
+    }
+
+    pub fn quantise_transpose_into_i16(&self, dest: &mut TransposedLayer<i16, M, N>, qa: i16) {
+        let mut untrans = [Accumulator([0; N]); M];
+
+        for (acc_i, acc_j) in untrans.iter_mut().zip(self.weights.iter()) {
+            *acc_i = acc_j.quantise_i16(qa);
+        }
+
+        for i in 0..N {
+            for (j, row) in untrans.iter().enumerate() {
+                dest.weights[i].0[j] = row.0[i];
+            }
+        }
+
+        dest.biases = self.biases.quantise_i16(qa);
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct TransposedLayer<T: Copy, const M: usize, const N: usize> {
+    weights: [Accumulator<T, M>; N],
+    biases: Accumulator<T, N>,
+}
+
+impl<const M: usize, const N: usize> TransposedLayer<i16, M, N> {
+    pub fn forward_from_i16<T: Activation, const QA: i16>(
+        &self,
+        inputs: &Accumulator<i16, M>,
+    ) -> Accumulator<f32, N> {
+        let mut act = [0; M];
+
+        for (a, &i) in act.iter_mut().zip(inputs.0.iter()) {
+            *a = (i32::from(i).clamp(0, i32::from(QA)).pow(2) / i32::from(QA)) as i16;
+        }
+
+        let mut fwd = [0; N];
+
+        for (f, row) in fwd.iter_mut().zip(self.weights.iter()) {
+            for (&a, &w) in act.iter().zip(row.0.iter()) {
+                *f += i32::from(a) * i32::from(w);
+            }
+        }
+
+        let mut res = [0.0; N];
+
+        for (r, (&f, &b)) in res.iter_mut().zip(fwd.iter().zip(self.biases.0.iter())) {
+            *r = (f as f32 / f32::from(QA) + f32::from(b)) / f32::from(QA);
+        }
+
+        Accumulator(res)
     }
 }

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -79,7 +79,7 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
         dest.biases = self.biases.quantise_i16(qa);
     }
 
-    pub fn quantise_into_i8(&self, dest: &mut Layer<i8, M, N>, qa: i8) {
+    pub fn quantise_into_i8(&self, dest: &mut Layer<i8, M, N>, qa: i16) {
         for (acc_i, acc_j) in dest.weights.iter_mut().zip(self.weights.iter()) {
             *acc_i = acc_j.quantise_i8(qa);
         }

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -71,7 +71,7 @@ struct UnquantisedSubNet {
 impl UnquantisedSubNet {
     fn quantise(&self, qa: i16) -> SubNet {
         SubNet {
-            ft: self.ft.quantise_i16(qa),
+            ft: self.ft.quantise_i16(qa, 1.98),
             l2: self.l2,
         }
     }

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -3,7 +3,9 @@ use crate::{
     chess::{Board, Move},
 };
 
-use super::{accumulator::Accumulator, activation::ReLU, layer::Layer, QA};
+use super::{accumulator::Accumulator, activation::ReLU, layer::Layer};
+
+const QA: i16 = 512;
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
@@ -19,7 +21,7 @@ struct SubNet {
 impl SubNet {
     fn out(&self, feats: &[usize]) -> Accumulator<f32, 16> {
         let l2 = self.ft.forward_from_slice(feats);
-        self.l2.forward_from_i16::<ReLU>(&l2)
+        self.l2.forward_from_i16::<ReLU, QA>(&l2)
     }
 }
 
@@ -69,7 +71,7 @@ struct UnquantisedSubNet {
 impl UnquantisedSubNet {
     fn quantise(&self, qa: i16) -> SubNet {
         SubNet {
-            ft: self.ft.quantise(qa),
+            ft: self.ft.quantise_i16(qa),
             l2: self.l2,
         }
     }

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,7 +4,7 @@ use super::{activation::SCReLU, layer::Layer};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-da9c86fe71e0.network";
+pub const ValueFileDefaultName: &str = "nn-8d75657f542f.network";
 
 const QA: i16 = 110;
 const SCALE: i32 = 400;
@@ -13,15 +13,8 @@ const SCALE: i32 = 400;
 pub struct ValueNetwork {
     l1: Layer<i8, { 768 * 4 }, 2048>,
     l2: Layer<f32, 2048, 16>,
-    l3: Layer<f32, 16, 16>,
-    l4: Layer<f32, 16, 16>,
-    l5: Layer<f32, 16, 16>,
-    l6: Layer<f32, 16, 16>,
-    l7: Layer<f32, 16, 16>,
-    l8: Layer<f32, 16, 16>,
-    l9: Layer<f32, 16, 16>,
-    l10: Layer<f32, 16, 16>,
-    l11: Layer<f32, 16, 1>,
+    l3: Layer<f32, 16, 128>,
+    l4: Layer<f32, 128, 1>,
 }
 
 impl ValueNetwork {
@@ -29,14 +22,7 @@ impl ValueNetwork {
         let l2 = self.l1.forward(board);
         let l3 = self.l2.forward_from_i16::<SCReLU, QA>(&l2);
         let l4 = self.l3.forward::<SCReLU>(&l3);
-        let l5 = self.l4.forward::<SCReLU>(&l4);
-        let l6 = self.l5.forward::<SCReLU>(&l5);
-        let l7 = self.l6.forward::<SCReLU>(&l6);
-        let l8 = self.l7.forward::<SCReLU>(&l7);
-        let l9 = self.l8.forward::<SCReLU>(&l8);
-        let l10 = self.l9.forward::<SCReLU>(&l9);
-        let l11 = self.l10.forward::<SCReLU>(&l10);
-        let out = self.l11.forward::<SCReLU>(&l11);
+        let out = self.l4.forward::<SCReLU>(&l4);
 
         (out.0[0] * SCALE as f32) as i32
     }
@@ -46,15 +32,8 @@ impl ValueNetwork {
 pub struct UnquantisedValueNetwork {
     l1: Layer<f32, { 768 * 4 }, 2048>,
     l2: Layer<f32, 2048, 16>,
-    l3: Layer<f32, 16, 16>,
-    l4: Layer<f32, 16, 16>,
-    l5: Layer<f32, 16, 16>,
-    l6: Layer<f32, 16, 16>,
-    l7: Layer<f32, 16, 16>,
-    l8: Layer<f32, 16, 16>,
-    l9: Layer<f32, 16, 16>,
-    l10: Layer<f32, 16, 16>,
-    l11: Layer<f32, 16, 1>,
+    l3: Layer<f32, 16, 128>,
+    l4: Layer<f32, 128, 1>,
 }
 
 impl UnquantisedValueNetwork {
@@ -66,13 +45,6 @@ impl UnquantisedValueNetwork {
         quantised.l2 = self.l2;
         quantised.l3 = self.l3;
         quantised.l4 = self.l4;
-        quantised.l5 = self.l5;
-        quantised.l6 = self.l6;
-        quantised.l7 = self.l7;
-        quantised.l8 = self.l8;
-        quantised.l9 = self.l9;
-        quantised.l10 = self.l10;
-        quantised.l11 = self.l11;
 
         quantised
     }

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -1,10 +1,10 @@
 use crate::{boxed_and_zeroed, Board};
 
-use super::{activation::SCReLU, layer::Layer};
+use super::{activation::SCReLU, layer::{Layer, TransposedLayer}};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-341a3b6ddb52.network";
+pub const ValueFileDefaultName: &str = "nn-70655825d9f7.network";
 
 const QA: i16 = 512;
 const SCALE: i32 = 400;
@@ -12,7 +12,7 @@ const SCALE: i32 = 400;
 #[repr(C)]
 pub struct ValueNetwork {
     l1: Layer<i16, { 768 * 4 }, 2048>,
-    l2: Layer<i16, 2048, 16>,
+    l2: TransposedLayer<i16, 2048, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 1>,
 }
@@ -41,7 +41,7 @@ impl UnquantisedValueNetwork {
         let mut quantised: Box<ValueNetwork> = unsafe { boxed_and_zeroed() };
 
         self.l1.quantise_into_i16(&mut quantised.l1, QA);
-        self.l2.quantise_into_i16(&mut quantised.l2, QA);
+        self.l2.quantise_transpose_into_i16(&mut quantised.l2, QA);
 
         quantised.l3 = self.l3;
         quantised.l4 = self.l4;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,9 +4,9 @@ use super::{activation::SCReLU, layer::Layer};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-fb9b3c6159b1.network";
+pub const ValueFileDefaultName: &str = "nn-19cc52a719f4.network";
 
-const QA: i16 = 110;
+const QA: i16 = 128;
 const SCALE: i32 = 400;
 
 #[repr(C)]
@@ -40,7 +40,7 @@ impl UnquantisedValueNetwork {
     pub fn quantise(&self) -> Box<ValueNetwork> {
         let mut quantised: Box<ValueNetwork> = unsafe { boxed_and_zeroed() };
 
-        self.l1.quantise_into_i8(&mut quantised.l1, QA as i8);
+        self.l1.quantise_into_i8(&mut quantised.l1, QA);
 
         quantised.l2 = self.l2;
         quantised.l3 = self.l3;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,9 +4,10 @@ use super::{activation::SCReLU, layer::{Layer, TransposedLayer}};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-70655825d9f7.network";
+pub const ValueFileDefaultName: &str = "nn-a3733871302c.network";
 
 const QA: i16 = 512;
+const QB: i16 = 1024;
 const SCALE: i32 = 400;
 
 #[repr(C)]
@@ -20,7 +21,7 @@ pub struct ValueNetwork {
 impl ValueNetwork {
     pub fn eval(&self, board: &Board) -> i32 {
         let l2 = self.l1.forward(board);
-        let l3 = self.l2.forward_from_i16::<SCReLU, QA>(&l2);
+        let l3 = self.l2.forward_from_i16::<SCReLU, QA, QB>(&l2);
         let l4 = self.l3.forward::<SCReLU>(&l3);
         let out = self.l4.forward::<SCReLU>(&l4);
 
@@ -41,7 +42,7 @@ impl UnquantisedValueNetwork {
         let mut quantised: Box<ValueNetwork> = unsafe { boxed_and_zeroed() };
 
         self.l1.quantise_into_i16(&mut quantised.l1, QA);
-        self.l2.quantise_transpose_into_i16(&mut quantised.l2, QA);
+        self.l2.quantise_transpose_into_i16(&mut quantised.l2, QB);
 
         quantised.l3 = self.l3;
         quantised.l4 = self.l4;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,15 +4,15 @@ use super::{activation::SCReLU, layer::Layer};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-19cc52a719f4.network";
+pub const ValueFileDefaultName: &str = "quantised.network";
 
-const QA: i16 = 128;
+const QA: i16 = 512;
 const SCALE: i32 = 400;
 
 #[repr(C)]
 pub struct ValueNetwork {
-    l1: Layer<i8, { 768 * 4 }, 2048>,
-    l2: Layer<f32, 2048, 16>,
+    l1: Layer<i16, { 768 * 4 }, 2048>,
+    l2: Layer<i16, 2048, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 1>,
 }
@@ -40,9 +40,9 @@ impl UnquantisedValueNetwork {
     pub fn quantise(&self) -> Box<ValueNetwork> {
         let mut quantised: Box<ValueNetwork> = unsafe { boxed_and_zeroed() };
 
-        self.l1.quantise_into_i8(&mut quantised.l1, QA);
+        self.l1.quantise_into_i16(&mut quantised.l1, QA);
+        self.l2.quantise_into_i16(&mut quantised.l2, QA);
 
-        quantised.l2 = self.l2;
         quantised.l3 = self.l3;
         quantised.l4 = self.l4;
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,7 +4,7 @@ use super::{activation::SCReLU, layer::Layer};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "quantised.network";
+pub const ValueFileDefaultName: &str = "nn-341a3b6ddb52.network";
 
 const QA: i16 = 512;
 const SCALE: i32 = 400;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,7 +4,7 @@ use super::{activation::SCReLU, layer::Layer};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-8d75657f542f.network";
+pub const ValueFileDefaultName: &str = "nn-fb9b3c6159b1.network";
 
 const QA: i16 = 110;
 const SCALE: i32 = 400;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -6,7 +6,7 @@ use super::{activation::SCReLU, layer::Layer};
 #[allow(non_upper_case_globals)]
 pub const ValueFileDefaultName: &str = "quantised.network";
 
-const QA: i16 = 128;
+const QA: i16 = 64;
 const SCALE: i32 = 400;
 
 #[repr(C)]

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,7 +4,7 @@ use super::{activation::SCReLU, layer::Layer};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "quantised.network";
+pub const ValueFileDefaultName: &str = "nn-e3559455baa7.network";
 
 const QA: i16 = 64;
 const SCALE: i32 = 400;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -4,9 +4,9 @@ use super::{activation::SCReLU, layer::Layer};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-e3559455baa7.network";
+pub const ValueFileDefaultName: &str = "nn-da9c86fe71e0.network";
 
-const QA: i16 = 64;
+const QA: i16 = 110;
 const SCALE: i32 = 400;
 
 #[repr(C)]

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -1,6 +1,9 @@
 use crate::{boxed_and_zeroed, Board};
 
-use super::{activation::SCReLU, layer::{Layer, TransposedLayer}};
+use super::{
+    activation::SCReLU,
+    layer::{Layer, TransposedLayer},
+};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
@@ -44,7 +47,8 @@ impl UnquantisedValueNetwork {
         let mut quantised: Box<ValueNetwork> = unsafe { boxed_and_zeroed() };
 
         self.l1.quantise_into_i16(&mut quantised.l1, QA, 0.99);
-        self.l2.quantise_transpose_into_i16(&mut quantised.l2, QB, 0.99);
+        self.l2
+            .quantise_transpose_into_i16(&mut quantised.l2, QB, 0.99);
 
         quantised.l3 = self.l3;
         quantised.l4 = self.l4;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -10,6 +10,8 @@ const QA: i16 = 512;
 const QB: i16 = 1024;
 const SCALE: i32 = 400;
 
+const FACTOR: i16 = 32;
+
 #[repr(C)]
 pub struct ValueNetwork {
     l1: Layer<i16, { 768 * 4 }, 2048>,
@@ -21,7 +23,7 @@ pub struct ValueNetwork {
 impl ValueNetwork {
     pub fn eval(&self, board: &Board) -> i32 {
         let l2 = self.l1.forward(board);
-        let l3 = self.l2.forward_from_i16::<SCReLU, QA, QB>(&l2);
+        let l3 = self.l2.forward_from_i16::<SCReLU, QA, QB, FACTOR>(&l2);
         let l4 = self.l3.forward::<SCReLU>(&l3);
         let out = self.l4.forward::<SCReLU>(&l4);
 
@@ -41,8 +43,8 @@ impl UnquantisedValueNetwork {
     pub fn quantise(&self) -> Box<ValueNetwork> {
         let mut quantised: Box<ValueNetwork> = unsafe { boxed_and_zeroed() };
 
-        self.l1.quantise_into_i16(&mut quantised.l1, QA);
-        self.l2.quantise_transpose_into_i16(&mut quantised.l2, QB);
+        self.l1.quantise_into_i16(&mut quantised.l1, QA, 0.99);
+        self.l2.quantise_transpose_into_i16(&mut quantised.l2, QB, 0.99);
 
         quantised.l3 = self.l3;
         quantised.l4 = self.l4;

--- a/train/value/src/bin/quantise.rs
+++ b/train/value/src/bin/quantise.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, UnquantisedValueNetwork, ValueNetwork};
 
 fn main() {
     let unquantised: Box<UnquantisedValueNetwork> =
-        unsafe { read_into_struct_unchecked("nn-2eeff9457b79.network") };
+        unsafe { read_into_struct_unchecked("nn-4bef54ac8e26.network") };
 
     let quantised = unquantised.quantise();
 

--- a/train/value/src/bin/quantise.rs
+++ b/train/value/src/bin/quantise.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, UnquantisedValueNetwork, ValueNetwork};
 
 fn main() {
     let unquantised: Box<UnquantisedValueNetwork> =
-        unsafe { read_into_struct_unchecked("nn-4bef54ac8e26.network") };
+        unsafe { read_into_struct_unchecked("nn-2eeff9457b79.network") };
 
     let quantised = unquantised.quantise();
 

--- a/train/value/src/bin/quantise.rs
+++ b/train/value/src/bin/quantise.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, UnquantisedValueNetwork, ValueNetwork};
 
 fn main() {
     let unquantised: Box<UnquantisedValueNetwork> =
-        unsafe { read_into_struct_unchecked("nn-4bef54ac8e26.network") };
+        unsafe { read_into_struct_unchecked("nn-57dea20e602a.network") };
 
     let quantised = unquantised.quantise();
 


### PR DESCRIPTION
Quantises L2 in value network + new arch `3072 -> 2048 -> 16 -> 128 -> 1` (close to neutral on its own).

Passed STC:
LLR: 3.74 (-2.94,2.94) <0.00,4.00>
Total: 3296 W: 995 L: 768 D: 1533
Ptnml(0-2): 56, 338, 670, 491, 93
https://montychess.org/tests/view/66cd138c5940a4e06cfcd44c

Passed LTC:
LLR: 3.59 (-2.94,2.94) <1.00,5.00>
Total: 8412 W: 2046 L: 1830 D: 4536
Ptnml(0-2): 71, 910, 2053, 1076, 96
https://montychess.org/tests/view/66cd16ea5940a4e06cfcd48e

Co-Authored-By: Viren6 <94880762+viren6@users.noreply.github.com>
Bench: 1316421