### PR TITLE
New Policy Network: `nn-1b01b6e89ea1.network`

### DIFF
--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -9,17 +9,17 @@ const QA: i16 = 512;
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const PolicyFileDefaultName: &str = "nn-e2a03baa505c.network";
+pub const PolicyFileDefaultName: &str = "nn-1b01b6e89ea1.network";
 
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct SubNet {
-    ft: Layer<i16, 768, 16>,
-    l2: Layer<f32, 16, 16>,
+    ft: Layer<i16, 768, 32>,
+    l2: Layer<f32, 32, 32>,
 }
 
 impl SubNet {
-    fn out(&self, feats: &[usize]) -> Accumulator<f32, 16> {
+    fn out(&self, feats: &[usize]) -> Accumulator<f32, 32> {
         let l2 = self.ft.forward_from_slice(feats);
         self.l2.forward_from_i16::<ReLU, QA>(&l2)
     }
@@ -28,21 +28,20 @@ impl SubNet {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PolicyNetwork {
-    subnets: [[SubNet; 2]; 448],
+    subnets: [[SubNet; 2]; 128],
     hce: Layer<f32, 4, 1>,
 }
 
 impl PolicyNetwork {
     pub fn get(&self, pos: &Board, mov: &Move, feats: &[usize], threats: u64) -> f32 {
         let flip = pos.flip_val();
-        let pc = pos.get_pc(1 << mov.src()) - 1;
 
         let from_threat = usize::from(threats & (1 << mov.src()) > 0);
         let from_subnet = &self.subnets[usize::from(mov.src() ^ flip)][from_threat];
         let from_vec = from_subnet.out(feats);
 
         let good_see = usize::from(pos.see(mov, -108));
-        let to_subnet = &self.subnets[64 * pc + usize::from(mov.to() ^ flip)][good_see];
+        let to_subnet = &self.subnets[64 + usize::from(mov.to() ^ flip)][good_see];
         let to_vec = to_subnet.out(feats);
 
         let hce = self.hce.forward::<ReLU>(&Self::get_hce_feats(pos, mov)).0[0];
@@ -64,8 +63,8 @@ impl PolicyNetwork {
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct UnquantisedSubNet {
-    ft: Layer<f32, 768, 16>,
-    l2: Layer<f32, 16, 16>,
+    ft: Layer<f32, 768, 32>,
+    l2: Layer<f32, 32, 32>,
 }
 
 impl UnquantisedSubNet {
@@ -80,7 +79,7 @@ impl UnquantisedSubNet {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct UnquantisedPolicyNetwork {
-    subnets: [[UnquantisedSubNet; 2]; 448],
+    subnets: [[UnquantisedSubNet; 2]; 128],
     hce: Layer<f32, 4, 1>,
 }
 

--- a/train/policy/src/arch.rs
+++ b/train/policy/src/arch.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 #[repr(C)]
 #[derive(Clone, Copy, FeedForwardNetwork)]
 pub struct SubNet {
-    ft: layer::SparseConnected<activation::ReLU, 768, 64>,
-    l2: layer::DenseConnected<activation::ReLU, 64, 64>,
+    ft: layer::SparseConnected<activation::ReLU, 768, 32>,
+    l2: layer::DenseConnected<activation::ReLU, 32, 32>,
 }
 
 impl SubNet {
@@ -87,7 +87,7 @@ impl PolicyNetwork {
             let mov = <Move as From<u16>>::from(mov);
 
             let from = usize::from(mov.src() ^ flip);
-            let to = usize::from(mov.to() ^ flip);
+            let to = usize::from(mov.to() ^ flip) + 64;
             let from_threat = usize::from(threats & (1 << mov.src()) > 0);
             let good_see = usize::from(board.see(&mov, -108));
 
@@ -113,7 +113,7 @@ impl PolicyNetwork {
 
         for (from_out, to_out, hce_out, mov, visits, score, good_see) in policies {
             let from = usize::from(mov.src() ^ flip);
-            let to = usize::from(mov.to() ^ flip);
+            let to = usize::from(mov.to() ^ flip) + 64;
             let from_threat = usize::from(threats & (1 << mov.src()) > 0);
             let hce_feats = PolicyNetwork::get_hce_feats(&board, &mov);
 

--- a/train/policy/src/arch.rs
+++ b/train/policy/src/arch.rs
@@ -29,7 +29,7 @@ impl SubNet {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PolicyNetwork {
-    pub subnets: [[SubNet; 2]; 448],
+    pub subnets: [[SubNet; 2]; 128],
     pub hce: layer::DenseConnected<activation::Identity, 4, 1>,
 }
 
@@ -85,10 +85,9 @@ impl PolicyNetwork {
 
         for &(mov, visits) in &pos.moves[..pos.num] {
             let mov = <Move as From<u16>>::from(mov);
-            let pc = board.get_pc(1 << mov.src()) - 1;
 
             let from = usize::from(mov.src() ^ flip);
-            let to = 64 * pc + usize::from(mov.to() ^ flip);
+            let to = usize::from(mov.to() ^ flip);
             let from_threat = usize::from(threats & (1 << mov.src()) > 0);
             let good_see = usize::from(board.see(&mov, -108));
 
@@ -113,9 +112,8 @@ impl PolicyNetwork {
         }
 
         for (from_out, to_out, hce_out, mov, visits, score, good_see) in policies {
-            let pc = board.get_pc(1 << mov.src()) - 1;
             let from = usize::from(mov.src() ^ flip);
-            let to = 64 * pc + usize::from(mov.to() ^ flip);
+            let to = usize::from(mov.to() ^ flip);
             let from_threat = usize::from(threats & (1 << mov.src()) > 0);
             let hce_feats = PolicyNetwork::get_hce_feats(&board, &mov);
 

--- a/train/policy/src/arch.rs
+++ b/train/policy/src/arch.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 #[repr(C)]
 #[derive(Clone, Copy, FeedForwardNetwork)]
 pub struct SubNet {
-    ft: layer::SparseConnected<activation::ReLU, 768, 16>,
-    l2: layer::DenseConnected<activation::ReLU, 16, 16>,
+    ft: layer::SparseConnected<activation::ReLU, 768, 64>,
+    l2: layer::DenseConnected<activation::ReLU, 64, 64>,
 }
 
 impl SubNet {

--- a/train/policy/src/bin/interleave.rs
+++ b/train/policy/src/bin/interleave.rs
@@ -6,7 +6,7 @@ use std::{
 use montyformat::MontyFormat;
 
 fn main() -> std::io::Result<()> {
-    let folder_path = "/home/admin/policy_data/MontyPolicy"; // Specify the folder to scan
+    let folder_path = "/home/neural/policy_data/64"; // Specify the folder to scan
     let output = "interleaved.binpack";
 
     // Scan the folder and collect file paths with the specified extension

--- a/train/policy/src/bin/quantise.rs
+++ b/train/policy/src/bin/quantise.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, PolicyNetwork, UnquantisedPolicyNetwork}
 
 fn main() {
     let unquantised: Box<UnquantisedPolicyNetwork> =
-        unsafe { read_into_struct_unchecked("nn-6b5dc1d7fff9.network") };
+        unsafe { read_into_struct_unchecked("policy-540.bin") };
 
     let quantised = unquantised.quantise();
 

--- a/train/policy/src/lib.rs
+++ b/train/policy/src/lib.rs
@@ -15,13 +15,13 @@ pub fn train(
     threads: usize,
     data_path: String,
     superbatches: usize,
-    lr_start: usize,
-    lr_end: usize,
+    lr_start: f32,
+    lr_end: f32,
     final_lr_superbatch: usize,
 ) {
     let mut policy = PolicyNetwork::rand_init();
 
-    let mut lr = lr_start
+    let mut lr = lr_start;
     let mut momentum = PolicyNetwork::boxed_and_zeroed();
     let mut velocity = PolicyNetwork::boxed_and_zeroed();
 
@@ -68,8 +68,8 @@ pub fn train(
 
             running_error = 0.0;
 
-            let decay_factor = (lr_end / lr_start).powf(1.0 / final_superbatch as f32);
-            lr = lr_start * decay_factor.powf(sb as f64);
+            let decay_factor = (lr_end / lr_start).powf(1.0 / final_lr_superbatch as f32);
+            lr = lr_start * decay_factor.powf(sb as f32);
             println!("Dropping LR to {lr}");
 
             if sb > 0 && (sb - 1) % 10 == 0 {

--- a/train/policy/src/lib.rs
+++ b/train/policy/src/lib.rs
@@ -72,8 +72,8 @@ pub fn train(
             lr = lr_start * decay_factor.powf(sb as f32);
             println!("Dropping LR to {lr}");
 
-            if sb > 0 && (sb - 1) % 10 == 0 {
-                policy.write_to_bin(format!("checkpoints/policy-{sb}.bin").as_str());
+            if sb > 1 && (sb - 1) % 10 == 0 {
+                policy.write_to_bin(format!("checkpoints/policy-{}.bin", sb - 1).as_str());
             }
 
             sb == superbatches

--- a/train/policy/src/lib.rs
+++ b/train/policy/src/lib.rs
@@ -15,11 +15,13 @@ pub fn train(
     threads: usize,
     data_path: String,
     superbatches: usize,
-    lr_drop: usize,
+    lr_start: usize,
+    lr_end: usize,
+    final_lr_superbatch: usize,
 ) {
     let mut policy = PolicyNetwork::rand_init();
 
-    let mut lr = 0.001;
+    let mut lr = lr_start
     let mut momentum = PolicyNetwork::boxed_and_zeroed();
     let mut velocity = PolicyNetwork::boxed_and_zeroed();
 
@@ -66,10 +68,9 @@ pub fn train(
 
             running_error = 0.0;
 
-            if sb % lr_drop == 0 {
-                lr *= 0.1;
-                println!("Dropping LR to {lr}");
-            }
+            let decay_factor = (lr_end / lr_start).powf(1.0 / final_superbatch as f32);
+            lr = lr_start * decay_factor.powf(sb as f64);
+            println!("Dropping LR to {lr}");
 
             policy.write_to_bin(format!("checkpoints/policy-{sb}.bin").as_str());
 

--- a/train/policy/src/lib.rs
+++ b/train/policy/src/lib.rs
@@ -72,8 +72,8 @@ pub fn train(
             lr = lr_start * decay_factor.powf(sb as f32);
             println!("Dropping LR to {lr}");
 
-            if sb > 1 && (sb - 1) % 10 == 0 {
-                policy.write_to_bin(format!("checkpoints/policy-{}.bin", sb - 1).as_str());
+            if sb % 10 == 0 {
+                policy.write_to_bin(format!("checkpoints/policy-{sb}.bin").as_str());
             }
 
             sb == superbatches

--- a/train/policy/src/lib.rs
+++ b/train/policy/src/lib.rs
@@ -72,7 +72,9 @@ pub fn train(
             lr = lr_start * decay_factor.powf(sb as f64);
             println!("Dropping LR to {lr}");
 
-            policy.write_to_bin(format!("checkpoints/policy-{sb}.bin").as_str());
+            if sb > 0 && (sb - 1) % 10 == 0 {
+                policy.write_to_bin(format!("checkpoints/policy-{sb}.bin").as_str());
+            }
 
             sb == superbatches
         } else {

--- a/train/policy/src/lib.rs
+++ b/train/policy/src/lib.rs
@@ -69,7 +69,12 @@ pub fn train(
             running_error = 0.0;
 
             let decay_factor = (lr_end / lr_start).powf(1.0 / final_lr_superbatch as f32);
-            lr = lr_start * decay_factor.powf(sb as f32);
+
+            if sb >= final_lr_superbatch {
+                lr = lr_end;
+            } else {
+                lr = lr_start * decay_factor.powf(sb as f32);
+            }
             println!("Dropping LR to {lr}");
 
             if sb % 10 == 0 {

--- a/train/policy/src/main.rs
+++ b/train/policy/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     policy::train(
         buffer_size_mb,
         threads,
-        "../binpacks/policygen6.binpack".to_string(),
+        "/home/neural/policy_data/interleaved.binpack".to_string(),
         60,
         25,
     );

--- a/train/policy/src/main.rs
+++ b/train/policy/src/main.rs
@@ -8,7 +8,9 @@ fn main() {
         buffer_size_mb,
         threads,
         "/home/neural/policy_data/interleaved.binpack".to_string(),
-        60,
-        25,
+        1500,
+        0.001,
+        0.0000001,
+        1500,
     );
 }

--- a/train/policy/src/main.rs
+++ b/train/policy/src/main.rs
@@ -8,9 +8,9 @@ fn main() {
         buffer_size_mb,
         threads,
         "/home/neural/policy_data/interleaved.binpack".to_string(),
-        1500,
+        540,
         0.001,
-        0.0000001,
-        1500,
+        0.000001,
+        540,
     );
 }


### PR DESCRIPTION
Increases L2/L3 from 16 to 32. This doubling in size is a 4x slowdown. Also removes piece buckets.

Training time was increased from 60 to 540 superbatches, with an additional LR drop. LR now decays exponentially.

Data used:
- 66cfe9e95940a4e06cfd11aa
- 66cfe9ea5940a4e06cfd11ac
- 66cfe9eb5940a4e06cfd11ae
- 66cfe9ec5940a4e06cfd11b0
- 66cfe9ed5940a4e06cfd11b3
- 66d1218a5940a4e06cfd2e4d
- 66d1218b5940a4e06cfd2e4f
- 66d1218c5940a4e06cfd2e51
- 66d1218d5940a4e06cfd2e53
- 66d1218e5940a4e06cfd2e55

Passed STC:
https://montychess.org/tests/view/66d501ac5940a4e06cfd8791
LLR: 2.91 (-2.94,2.94) <0.00,4.00>
Total: 8064 W: 2347 L: 2149 D: 3568
Ptnml(0-2): 168, 934, 1691, 1010, 229

Passed LTC:
https://montychess.org/tests/view/66d504e45940a4e06cfd87fc
LLR: 2.95 (-2.94,2.94) <1.00,5.00>
Total: 2232 W: 634 L: 469 D: 1129
Ptnml(0-2): 15, 232, 486, 339, 44

Bench: 1116723

