### PR TITLE
New Value Network: `nn-4587c7cdf848.network`

### DIFF
--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -9,17 +9,17 @@ const QA: i16 = 512;
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const PolicyFileDefaultName: &str = "nn-e2a03baa505c.network";
+pub const PolicyFileDefaultName: &str = "nn-1b01b6e89ea1.network";
 
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct SubNet {
-    ft: Layer<i16, 768, 16>,
-    l2: Layer<f32, 16, 16>,
+    ft: Layer<i16, 768, 32>,
+    l2: Layer<f32, 32, 32>,
 }
 
 impl SubNet {
-    fn out(&self, feats: &[usize]) -> Accumulator<f32, 16> {
+    fn out(&self, feats: &[usize]) -> Accumulator<f32, 32> {
         let l2 = self.ft.forward_from_slice(feats);
         self.l2.forward_from_i16::<ReLU, QA>(&l2)
     }
@@ -28,21 +28,20 @@ impl SubNet {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PolicyNetwork {
-    subnets: [[SubNet; 2]; 448],
+    subnets: [[SubNet; 2]; 128],
     hce: Layer<f32, 4, 1>,
 }
 
 impl PolicyNetwork {
     pub fn get(&self, pos: &Board, mov: &Move, feats: &[usize], threats: u64) -> f32 {
         let flip = pos.flip_val();
-        let pc = pos.get_pc(1 << mov.src()) - 1;
 
         let from_threat = usize::from(threats & (1 << mov.src()) > 0);
         let from_subnet = &self.subnets[usize::from(mov.src() ^ flip)][from_threat];
         let from_vec = from_subnet.out(feats);
 
         let good_see = usize::from(pos.see(mov, -108));
-        let to_subnet = &self.subnets[64 * pc + usize::from(mov.to() ^ flip)][good_see];
+        let to_subnet = &self.subnets[64 + usize::from(mov.to() ^ flip)][good_see];
         let to_vec = to_subnet.out(feats);
 
         let hce = self.hce.forward::<ReLU>(&Self::get_hce_feats(pos, mov)).0[0];
@@ -64,8 +63,8 @@ impl PolicyNetwork {
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct UnquantisedSubNet {
-    ft: Layer<f32, 768, 16>,
-    l2: Layer<f32, 16, 16>,
+    ft: Layer<f32, 768, 32>,
+    l2: Layer<f32, 32, 32>,
 }
 
 impl UnquantisedSubNet {
@@ -80,7 +79,7 @@ impl UnquantisedSubNet {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct UnquantisedPolicyNetwork {
-    subnets: [[UnquantisedSubNet; 2]; 448],
+    subnets: [[UnquantisedSubNet; 2]; 128],
     hce: Layer<f32, 4, 1>,
 }
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -7,7 +7,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-a5a5e79c914e.network";
+pub const ValueFileDefaultName: &str = "nn-4587c7cdf848.network";
 
 const QA: i16 = 512;
 const QB: i16 = 1024;
@@ -17,8 +17,8 @@ const FACTOR: i16 = 32;
 
 #[repr(C)]
 pub struct ValueNetwork {
-    l1: Layer<i16, { 768 * 4 }, 2048>,
-    l2: TransposedLayer<i16, 2048, 16>,
+    l1: Layer<i16, { 768 * 4 }, 4096>,
+    l2: TransposedLayer<i16, 4096, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 1>,
 }
@@ -36,8 +36,8 @@ impl ValueNetwork {
 
 #[repr(C)]
 pub struct UnquantisedValueNetwork {
-    l1: Layer<f32, { 768 * 4 }, 2048>,
-    l2: Layer<f32, 2048, 16>,
+    l1: Layer<f32, { 768 * 4 }, 4096>,
+    l2: Layer<f32, 4096, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 1>,
 }

--- a/train/policy/src/bin/quantise.rs
+++ b/train/policy/src/bin/quantise.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, PolicyNetwork, UnquantisedPolicyNetwork}
 
 fn main() {
     let unquantised: Box<UnquantisedPolicyNetwork> =
-        unsafe { read_into_struct_unchecked("nn-6b5dc1d7fff9.network") };
+        unsafe { read_into_struct_unchecked("policy-540.bin") };
 
     let quantised = unquantised.quantise();
 


### PR DESCRIPTION
Increased L1 from 2048 to 4096. Also 2.5x training time from 1200 to 3000 superbatches. LR has an extra 10x drop and now decays exponentially. 

Data used:
- 66b1a5e70f6f1e65cfa2c1c6
- 66b281d40f6f1e65cfa2cbf9
- 66b3f1a23ae9310e136db0a4
- 66b455273ae9310e136db441
- 66b58ea73ae9310e136dbf1e
- 66b71f2e3ae9310e136dca1c
- 66b7d2273ae9310e136dd0c1
- 66bbdb083ae9310e136ded1e
- 66bdb9a268e8f7e2fe23d245
- 66bf65fa5bf757f29ee42c72
- 66c114d943db0697ee163bfc
- 66c2739e43db0697ee16596b
- 66c3cef543db0697ee1676a6
- 66c5181743db0697ee1691c5
- 66c6561643db0697ee16acb6
- 66c7a8b943db0697ee16c8b5
- 66c8e86943db0697ee16e35f
- 66ca7d6b7f3228f03eb71e52
- 66cbd5295940a4e06cfcbaee
- 66cd43615940a4e06cfcd72a
- 66ce66ea5940a4e06cfcf14d
- 66cf04095940a4e06cfcfe87

Passed STC:
https://montychess.org/tests/view/66d5066f5940a4e06cfd8806
LLR: 2.91 (-2.94,2.94) <0.00,4.00>
Total: 3872 W: 1192 L: 1002 D: 1678
Ptnml(0-2): 95, 408, 778, 522, 133

Passed LTC:
https://montychess.org/tests/view/66d508015940a4e06cfd880d
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 1770 W: 500 L: 336 D: 934
Ptnml(0-2): 17, 152, 395, 292, 29

Bench: 1305294