### PR TITLE
Improve policy UCI

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -121,7 +121,8 @@ impl Uci {
                         total += *p;
                     }
 
-                    moves.sort_by_key(|(_, p)| (p * 1000.0) as u32);
+                    // Sort the moves by probability in descending order.
+                    moves.sort_by(|(_, p1), (_, p2)| p2.partial_cmp(p1).unwrap());
 
                     for (s, p) in moves {
                         println!("{s} -> {:.2}%", p / total * 100.0);


### PR DESCRIPTION
Moves are now correctly sorted in descending order based on their floating-point probabilities.
Uses proper floating-point comparison (partial_cmp) for sorting to avoid truncation and rounding errors.

No functional change.
Bench: 1305294