### PR TITLE
Implement mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +298,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 name = "monty"
 version = "1.0.0"
 dependencies = [
+ "memmap2",
  "sha2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,24 +159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
-
-[[package]]
-name = "log"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "memchr"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
 name = "memmap2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,12 +166,6 @@ checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "monty"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,8 @@ tunable = []
 members = ["datagen", "train/policy", "train/value"]
 resolver = "2"
 
+[dependencies]
+memmap2 = "0.9.5"
+
 [build-dependencies]
 sha2 = "0.10.8"

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ else
 endif
 
 default:
-	cargo rustc --release --bin monty -- -C target-cpu=native --emit link=$(NAME)
+	cargo rustc --release --bin monty --features=embed -- -C target-cpu=native --emit link=$(NAME)
 
 montytest:
 	cargo rustc --release --bin monty --features=uci-minimal,tunable -- -C target-cpu=native --emit link=$(NAME)
 
-embed:
-	cargo rustc --release --bin monty --features=embed -- -C target-cpu=native --emit link=$(NAME)
+noembed:
+	cargo rustc --release --bin monty -- -C target-cpu=native --emit link=$(NAME)
 
 gen:
 	cargo rustc --release --package datagen --bin datagen -- -C target-cpu=native --emit link=$(NAME)

--- a/README.md
+++ b/README.md
@@ -6,17 +6,11 @@
 </div>
 
 ## Compiling
-To compile without embedding the networks, run
+To compile, run
 ```
-make EXE=<output path>
+make
 ```
-when running the executable it will search for the networks in the current working directory.
-
-To compile and embed the networks in the exectuable, run
-```
-make embed EXE=<output path>
-```
-the required networks should be downloaded automatically (and validated).
+The required networks will be downloaded automatically (and validated).
 
 ## Development
 

--- a/datagen/src/main.rs
+++ b/datagen/src/main.rs
@@ -1,18 +1,24 @@
 use datagen::{parse_args, run_datagen};
-use monty::{read_into_struct_unchecked, ChessState, MctsParams, Uci};
+use monty::{read_into_struct_unchecked, ChessState, MappedStruct, MctsParams, Uci};
 
 fn main() {
     let mut args = std::env::args();
     args.next();
 
-    let policy = unsafe { read_into_struct_unchecked(monty::PolicyFileDefaultName) };
-    let value = unsafe { read_into_struct_unchecked(monty::ValueFileDefaultName) };
+    let policy_mapped: MappedStruct<monty::PolicyNetwork> =
+        unsafe { read_into_struct_unchecked(monty::PolicyFileDefaultName) };
+
+    let value_mapped: MappedStruct<monty::ValueNetwork> =
+        unsafe { read_into_struct_unchecked(monty::ValueFileDefaultName) };
+
+    let policy = &policy_mapped.data;
+    let value = &value_mapped.data;
 
     let params = MctsParams::default();
 
     if let Some(opts) = parse_args(args) {
-        run_datagen(params, opts, &policy, &value);
+        run_datagen(params, opts, policy, value);
     } else {
-        Uci::bench(ChessState::BENCH_DEPTH, &policy, &value, &params);
+        Uci::bench(ChessState::BENCH_DEPTH, policy, value, &params);
     }
 }

--- a/datagen/src/main.rs
+++ b/datagen/src/main.rs
@@ -1,14 +1,14 @@
 use datagen::{parse_args, run_datagen};
-use monty::{read_into_struct_unchecked, ChessState, MappedStruct, MctsParams, Uci};
+use monty::{read_into_struct_unchecked, ChessState, MappedWeights, MctsParams, Uci};
 
 fn main() {
     let mut args = std::env::args();
     args.next();
 
-    let policy_mapped: MappedStruct<monty::PolicyNetwork> =
+    let policy_mapped: MappedWeights<monty::PolicyNetwork> =
         unsafe { read_into_struct_unchecked(monty::PolicyFileDefaultName) };
 
-    let value_mapped: MappedStruct<monty::ValueNetwork> =
+    let value_mapped: MappedWeights<monty::ValueNetwork> =
         unsafe { read_into_struct_unchecked(monty::ValueFileDefaultName) };
 
     let policy = &policy_mapped.data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use networks::{
 pub use tree::Tree;
 pub use uci::Uci;
 
-pub struct MappedStruct<'a, T> {
+pub struct MappedWeights<'a, T> {
     pub mmap: Mmap,  // The memory-mapped file
     pub data: &'a T, // A reference to the data in the mmap
 }
@@ -56,7 +56,7 @@ pub unsafe fn boxed_and_zeroed<T>() -> Box<T> {
 
 /// # Safety
 /// Only to be used internally.
-pub unsafe fn read_into_struct_unchecked<'a, T>(path: &str) -> MappedStruct<'a, T> {
+pub unsafe fn read_into_struct_unchecked<'a, T>(path: &str) -> MappedWeights<'a, T> {
     let f = std::fs::File::open(path).unwrap();
     let mmap = Mmap::map(&f).unwrap();
 
@@ -74,8 +74,8 @@ pub unsafe fn read_into_struct_unchecked<'a, T>(path: &str) -> MappedStruct<'a, 
         panic!("Memory is not properly aligned for the type");
     }
 
-    MappedStruct {
-        mmap, // This ensures the memory is valid as long as MappedStruct exists
+    MappedWeights {
+        mmap, // This ensures the memory is valid as long as MappedWeights exists
         data: &*ptr,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,16 +35,16 @@ mod net {
 
 #[cfg(not(feature = "embed"))]
 mod nonet {
-    use monty::{read_into_struct_unchecked, ChessState, MappedStruct, MctsParams, Uci};
+    use monty::{read_into_struct_unchecked, ChessState, MappedWeights, MctsParams, Uci};
 
     pub fn run() {
         let mut args = std::env::args();
         let arg1 = args.nth(1);
 
-        let policy_mapped: MappedStruct<monty::PolicyNetwork> =
+        let policy_mapped: MappedWeights<monty::PolicyNetwork> =
             unsafe { read_into_struct_unchecked(monty::PolicyFileDefaultName) };
 
-        let value_mapped: MappedStruct<monty::ValueNetwork> =
+        let value_mapped: MappedWeights<monty::ValueNetwork> =
             unsafe { read_into_struct_unchecked(monty::ValueFileDefaultName) };
 
         let policy = policy_mapped.data;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,26 +35,31 @@ mod net {
 
 #[cfg(not(feature = "embed"))]
 mod nonet {
-    use monty::{read_into_struct_unchecked, ChessState, MctsParams, Uci};
+    use monty::{read_into_struct_unchecked, ChessState, MappedStruct, MctsParams, Uci};
 
     pub fn run() {
         let mut args = std::env::args();
         let arg1 = args.nth(1);
 
-        let policy = unsafe { read_into_struct_unchecked(monty::PolicyFileDefaultName) };
+        let policy_mapped: MappedStruct<monty::PolicyNetwork> =
+            unsafe { read_into_struct_unchecked(monty::PolicyFileDefaultName) };
 
-        let value = unsafe { read_into_struct_unchecked(monty::ValueFileDefaultName) };
+        let value_mapped: MappedStruct<monty::ValueNetwork> =
+            unsafe { read_into_struct_unchecked(monty::ValueFileDefaultName) };
+
+        let policy = policy_mapped.data;
+        let value = value_mapped.data;
 
         if let Some("bench") = arg1.as_deref() {
             Uci::bench(
                 ChessState::BENCH_DEPTH,
-                &policy,
-                &value,
+                policy,
+                value,
                 &MctsParams::default(),
             );
             return;
         }
 
-        Uci::run(&policy, &value);
+        Uci::run(policy, value);
     }
 }


### PR DESCRIPTION
Enables all Monty instances to share the same net weights in memory. Also sets make to embed nets by default.

Test: https://tests.montychess.org/tests/live_elo/670078f9b12c9e78f1354a35

No functional change.

Bench: 1358297