### PR TITLE
Increased pst for winning nodes

### DIFF
--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -56,6 +56,13 @@ impl SearchHelpers {
         Self::base_explore_scaling(params, node)
     }
 
+    /// Common depth PST
+    pub fn get_pst(q: f32, params: &MctsParams) -> f32 {
+        let scalar = q - q.min(params.winning_pst_threshold());
+        let t = scalar / (1.0 - params.winning_pst_threshold());
+        1.0 + (params.winning_pst_max() - 1.0) * t
+    }
+
     /// First Play Urgency
     ///
     /// #### Note

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -132,6 +132,8 @@ macro_rules! make_mcts_params {
 make_mcts_params! {
     root_pst: f32 = 3.64, 1.0, 10.0, 0.4, 0.002;
     depth_2_pst: f32 = 1.2, 1.0, 10.0, 0.4, 0.002;
+    winning_pst_threshold: f32 = 0.7, 0.0, 1.0, 0.05, 0.002;
+    winning_pst_max: f32 = 1.5, 0.1, 10.0, 0.4, 0.002;
     root_cpuct: f32 = 0.314, 0.1, 5.0, 0.065, 0.002;
     cpuct: f32 = 0.314, 0.1, 5.0, 0.065, 0.002;
     cpuct_var_weight: f32 = 0.851, 0.0, 2.0, 0.085, 0.002;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -11,7 +11,7 @@ use std::{
     time::Instant,
 };
 
-use crate::{chess::ChessState, GameState, MctsParams, PolicyNetwork};
+use crate::{chess::ChessState, mcts::SearchHelpers, GameState, MctsParams, PolicyNetwork};
 
 pub struct Tree {
     tree: [TreeHalf; 2],
@@ -185,7 +185,7 @@ impl Tree {
             0 => unreachable!(),
             1 => params.root_pst(),
             2 => params.depth_2_pst(),
-            3.. => 1.0,
+            3.. => SearchHelpers::get_pst(self[node_ptr].q(), params),
         };
 
         let mut total = 0.0;


### PR DESCRIPTION
Adjust the policy softmax temperature as the node Q is approaching winning state

STC
LLR: 3.00 (-2.94,2.94) <0.00,4.00>
Total: 34976 W: 8191 L: 7921 D: 18864
Ptnml(0-2): 434, 4052, 8304, 4206, 492
https://tests.montychess.org/tests/live_elo/67157c9eb12c9e78f1354d06

LTC
LLR: 2.93 (-2.94,2.94) <1.00,5.00>
Total: 128160 W: 27154 L: 26425 D: 74581
Ptnml(0-2): 829, 14632, 32502, 15215, 902
https://tests.montychess.org/tests/live_elo/67159ec9b12c9e78f1354d27

Rebased STC
LLR: 2.95 (-2.94,2.94) <0.00,4.00>
Total: 30528 W: 6868 L: 6621 D: 17039
Ptnml(0-2): 364, 3407, 7475, 3654, 364
https://tests.montychess.org/tests/live_elo/67241fbfb12c9e78f1354f49

Bench: 1586397