### PR TITLE
New Policy Network: `nn-2f9491f0e187.network`

### DIFF
--- a/src/chess.rs
+++ b/src/chess.rs
@@ -140,14 +140,14 @@ impl ChessState {
         self.stm()
     }
 
-    pub fn get_policy_feats(&self, policy: &PolicyNetwork) -> Accumulator<f32, 128> {
+    pub fn get_policy_feats(&self, policy: &PolicyNetwork) -> Accumulator<i16, 128> {
         policy.hl(&self.board)
     }
 
     pub fn get_policy(
         &self,
         mov: Move,
-        hl: &Accumulator<f32, 128>,
+        hl: &Accumulator<i16, 128>,
         policy: &PolicyNetwork,
     ) -> f32 {
         policy.get(&self.board, &mov, hl)

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -140,14 +140,14 @@ impl ChessState {
         self.stm()
     }
 
-    pub fn get_policy_feats(&self, policy: &PolicyNetwork) -> Accumulator<i16, 128> {
+    pub fn get_policy_feats(&self, policy: &PolicyNetwork) -> Accumulator<i16, 2048> {
         policy.hl(&self.board)
     }
 
     pub fn get_policy(
         &self,
         mov: Move,
-        hl: &Accumulator<i16, 128>,
+        hl: &Accumulator<i16, 2048>,
         policy: &PolicyNetwork,
     ) -> f32 {
         policy.get(&self.board, &mov, hl)

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -4,9 +4,9 @@ mod consts;
 mod frc;
 mod moves;
 
-use crate::{MctsParams, PolicyNetwork, ValueNetwork};
+use crate::{networks::Accumulator, MctsParams, PolicyNetwork, ValueNetwork};
 
-pub use self::{board::Board, frc::Castling, moves::Move};
+pub use self::{attacks::Attacks, board::Board, frc::Castling, moves::Move};
 
 const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
@@ -140,19 +140,17 @@ impl ChessState {
         self.stm()
     }
 
-    pub fn get_policy_feats(&self) -> (Vec<usize>, u64) {
-        let mut feats = Vec::with_capacity(32);
-        self.board.map_policy_features(|feat| feats.push(feat));
-        (feats, self.board.threats())
+    pub fn get_policy_feats(&self, policy: &PolicyNetwork) -> Accumulator<f32, 128> {
+        policy.hl(&self.board)
     }
 
     pub fn get_policy(
         &self,
         mov: Move,
-        (feats, threats): &(Vec<usize>, u64),
+        hl: &Accumulator<f32, 128>,
         policy: &PolicyNetwork,
     ) -> f32 {
-        policy.get(&self.board, &mov, feats, *threats)
+        policy.get(&self.board, &mov, hl)
     }
 
     #[cfg(not(feature = "datagen"))]
@@ -189,7 +187,7 @@ impl ChessState {
     }
 
     pub fn display(&self, policy: &PolicyNetwork) {
-        let feats = self.get_policy_feats();
+        let feats = self.get_policy_feats(policy);
         let mut moves = Vec::new();
         let mut max = f32::NEG_INFINITY;
         self.map_legal_moves(|mov| {

--- a/src/chess/attacks.rs
+++ b/src/chess/attacks.rs
@@ -91,6 +91,16 @@ impl Attacks {
     pub const fn black_pawn_setwise(pawns: u64) -> u64 {
         ((pawns & !File::A) >> 9) | ((pawns & !File::H) >> 7)
     }
+
+    pub const ALL_DESTINATIONS: [u64; 64] = init!(|sq, 64| {
+        let rank = sq / 8;
+        let file = sq % 8;
+    
+        let rooks = (0xFF << (rank * 8)) ^ (File::A << file);
+        let bishops = DIAGS[file + rank].swap_bytes() ^ DIAGS[7 + file - rank];
+    
+        rooks | bishops | KNIGHT[sq] | KING[sq]
+    });
 }
 
 struct File;

--- a/src/chess/attacks.rs
+++ b/src/chess/attacks.rs
@@ -95,10 +95,10 @@ impl Attacks {
     pub const ALL_DESTINATIONS: [u64; 64] = init!(|sq, 64| {
         let rank = sq / 8;
         let file = sq % 8;
-    
+
         let rooks = (0xFF << (rank * 8)) ^ (File::A << file);
         let bishops = DIAGS[file + rank].swap_bytes() ^ DIAGS[7 + file - rank];
-    
+
         rooks | bishops | KNIGHT[sq] | KING[sq]
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use chess::{Board, Castling, ChessState, GameState, Move};
 pub use mcts::{Limits, MctsParams, Searcher};
 use memmap2::Mmap;
 pub use networks::{
-    PolicyFileDefaultName, PolicyNetwork, UnquantisedPolicyNetwork, UnquantisedValueNetwork,
+    PolicyFileDefaultName, PolicyNetwork, UnquantisedValueNetwork,
     ValueFileDefaultName, ValueNetwork,
 };
 pub use tree::Tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use chess::{Board, Castling, ChessState, GameState, Move};
 pub use mcts::{Limits, MctsParams, Searcher};
 use memmap2::Mmap;
 pub use networks::{
-    PolicyFileDefaultName, PolicyNetwork, UnquantisedValueNetwork,
+    PolicyFileDefaultName, PolicyNetwork, UnquantisedPolicyNetwork, UnquantisedValueNetwork,
     ValueFileDefaultName, ValueNetwork,
 };
 pub use tree::Tree;

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -4,5 +4,6 @@ mod layer;
 mod policy;
 mod value;
 
-pub use policy::{PolicyFileDefaultName, PolicyNetwork, UnquantisedPolicyNetwork};
+pub use accumulator::Accumulator;
+pub use policy::{PolicyFileDefaultName, PolicyNetwork};
 pub use value::{UnquantisedValueNetwork, ValueFileDefaultName, ValueNetwork};

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -5,5 +5,5 @@ mod policy;
 mod value;
 
 pub use accumulator::Accumulator;
-pub use policy::{PolicyFileDefaultName, PolicyNetwork};
+pub use policy::{PolicyFileDefaultName, PolicyNetwork, UnquantisedPolicyNetwork};
 pub use value::{UnquantisedValueNetwork, ValueFileDefaultName, ValueNetwork};

--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -57,6 +57,20 @@ impl<const N: usize> Accumulator<i16, N> {
     }
 }
 
+impl<const N: usize> Accumulator<i16, N> {
+    pub fn dot<T: Activation, const QA: i16>(&self, other: &Self) -> f32 {
+        let mut res = 0.0;
+
+        for (i, j) in self.0.iter().zip(other.0.iter()) {
+            let i = f32::from(*i);
+            let j = f32::from(*j);
+            res += T::activate(i) * T::activate(j);
+        }
+
+        res / f32::from(QA) / f32::from(QA)
+    }
+}
+
 impl<const N: usize> Accumulator<f32, N> {
     pub fn dot<T: Activation>(&self, other: &Self) -> f32 {
         let mut res = 0.0;

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -5,8 +5,8 @@ use super::{accumulator::Accumulator, activation::Activation};
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct Layer<T: Copy, const M: usize, const N: usize> {
-    weights: [Accumulator<T, N>; M],
-    biases: Accumulator<T, N>,
+    pub weights: [Accumulator<T, N>; M],
+    pub biases: Accumulator<T, N>,
 }
 
 impl<const M: usize, const N: usize> Layer<i16, M, N> {
@@ -21,16 +21,6 @@ impl<const M: usize, const N: usize> Layer<i16, M, N> {
         let mut out = self.biases;
 
         out.add_multi(&feats[..count], &self.weights);
-
-        out
-    }
-
-    pub fn forward_from_slice(&self, feats: &[usize]) -> Accumulator<i16, N> {
-        let mut out = self.biases;
-
-        for &feat in feats {
-            out.add(&self.weights[feat])
-        }
 
         out
     }
@@ -54,17 +44,6 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
         }
 
         dest.biases = self.biases.quantise_i16(qa, warn_limit);
-    }
-
-    pub fn quantise_i16(&self, qa: i16, warn_limit: f32) -> Layer<i16, M, N> {
-        let mut res = Layer {
-            weights: [Accumulator([0; N]); M],
-            biases: Accumulator([0; N]),
-        };
-
-        self.quantise_into_i16(&mut res, qa, warn_limit);
-
-        res
     }
 
     pub fn quantise_transpose_into_i16(

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -71,8 +71,8 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TransposedLayer<T: Copy, const M: usize, const N: usize> {
-    weights: [Accumulator<T, M>; N],
-    biases: Accumulator<T, N>,
+    pub weights: [Accumulator<T, M>; N],
+    pub biases: Accumulator<T, N>,
 }
 
 impl<const M: usize, const N: usize> TransposedLayer<i16, M, N> {

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -48,20 +48,6 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
         fwd
     }
 
-    pub fn forward_from_i16<T: Activation, const QA: i16>(
-        &self,
-        inputs: &Accumulator<i16, M>,
-    ) -> Accumulator<f32, N> {
-        let mut fwd = self.biases;
-
-        for (i, d) in inputs.0.iter().zip(self.weights.iter()) {
-            let act = T::activate(f32::from(*i) / f32::from(QA));
-            fwd.madd(act, d);
-        }
-
-        fwd
-    }
-
     pub fn quantise_into_i16(&self, dest: &mut Layer<i16, M, N>, qa: i16, warn_limit: f32) {
         for (acc_i, acc_j) in dest.weights.iter_mut().zip(self.weights.iter()) {
             *acc_i = acc_j.quantise_i16(qa, warn_limit);

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -52,7 +52,7 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
         qa: i16,
         warn_limit: f32,
     ) {
-        let mut untrans = [Accumulator([0; N]); M];
+        let mut untrans = vec![Accumulator([0; N]); M];
 
         for (acc_i, acc_j) in untrans.iter_mut().zip(self.weights.iter()) {
             *acc_i = acc_j.quantise_i16(qa, warn_limit);

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -1,6 +1,12 @@
-use crate::{boxed_and_zeroed, chess::{Attacks, Board, Move}};
+use crate::{
+    boxed_and_zeroed,
+    chess::{Attacks, Board, Move},
+};
 
-use super::{accumulator::Accumulator, layer::{Layer, TransposedLayer}};
+use super::{
+    accumulator::Accumulator,
+    layer::{Layer, TransposedLayer},
+};
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
@@ -26,14 +32,15 @@ impl PolicyNetwork {
         pos.map_policy_features(|feat| res.add(&self.l1.weights[feat]));
 
         for elem in &mut res.0 {
-            *elem = (i32::from(*elem).clamp(0, i32::from(QA)).pow(2) / i32::from(QA / FACTOR)) as i16;
+            *elem =
+                (i32::from(*elem).clamp(0, i32::from(QA)).pow(2) / i32::from(QA / FACTOR)) as i16;
         }
 
         res
     }
 
     pub fn get(&self, pos: &Board, mov: &Move, hl: &Accumulator<i16, L1>) -> f32 {
-        let idx = map_move_to_index(pos, *mov);      
+        let idx = map_move_to_index(pos, *mov);
         let weights = &self.l2.weights[idx];
 
         let mut res = 0;
@@ -61,9 +68,9 @@ fn map_move_to_index(pos: &Board, mov: Move) -> usize {
         let flip = if pos.stm() == 1 { 56 } else { 0 };
         let from = usize::from(mov.src() ^ flip);
         let dest = usize::from(mov.to() ^ flip);
-    
+
         let below = Attacks::ALL_DESTINATIONS[from] & ((1 << dest) - 1);
-    
+
         OFFSETS[from] + below.count_ones() as usize
     };
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -169,7 +169,7 @@ impl Tree {
             return Some(());
         }
 
-        let feats = pos.get_policy_feats();
+        let feats = pos.get_policy_feats(policy);
         let mut max = f32::NEG_INFINITY;
         let mut actions = Vec::new();
 
@@ -222,7 +222,7 @@ impl Tree {
         policy: &PolicyNetwork,
         depth: u8,
     ) {
-        let feats = pos.get_policy_feats();
+        let feats = pos.get_policy_feats(policy);
         let mut max = f32::NEG_INFINITY;
 
         let mut policies = Vec::new();

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -99,7 +99,7 @@ impl Uci {
                     println!("wdl: {:.2}%", 100.0 * pos.get_value_wdl(value, &params));
                 }
                 "policy" => {
-                    let f = pos.get_policy_feats();
+                    let f = pos.get_policy_feats(policy);
                     let mut max = f32::NEG_INFINITY;
                     let mut moves = Vec::new();
 

--- a/train/policy/src/bin/quantise.rs
+++ b/train/policy/src/bin/quantise.rs
@@ -1,12 +1,12 @@
 use std::io::Write;
 
-use monty::{read_into_struct_unchecked, PolicyNetwork, UnquantisedPolicyNetwork};
+use monty::{read_into_struct_unchecked, MappedWeights, PolicyNetwork, UnquantisedPolicyNetwork};
 
 fn main() {
-    let unquantised: Box<UnquantisedPolicyNetwork> =
-        unsafe { read_into_struct_unchecked("policy-540.bin") };
+    let unquantised: MappedWeights<UnquantisedPolicyNetwork> =
+        unsafe { read_into_struct_unchecked("nn-7b30080083d5.network") };
 
-    let quantised = unquantised.quantise();
+    let quantised = unquantised.data.quantise();
 
     let mut file = std::fs::File::create("quantised.network").unwrap();
 

--- a/train/policy/src/bin/quantise.rs
+++ b/train/policy/src/bin/quantise.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, MappedWeights, PolicyNetwork, Unquantise
 
 fn main() {
     let unquantised: MappedWeights<UnquantisedPolicyNetwork> =
-        unsafe { read_into_struct_unchecked("nn-7b30080083d5.network") };
+        unsafe { read_into_struct_unchecked("policy001-270.network") };
 
     let quantised = unquantised.data.quantise();
 


### PR DESCRIPTION
Changes policy network architecture from the attention-style subnets to `3072 -> 2048 -> 3760`.

The 3072 inputs are threat inputs, much like the current value net, except without horizontal mirroring (for now).

The 3760 outputs are 2x1880 outputs, where the 1880 outputs are a **unique** mapping of moves to indices (including promotions), and moves are distinguished by whether they have good/bad SEE.

Training code can be found in [montytrain](https://github.com/official-monty/montytrain).

Passed STC:
LLR: 2.91 (-2.94,2.94) <0.00,4.00>
Total: 1280 W: 396 L: 240 D: 644
Ptnml(0-2): 7, 96, 304, 200, 33
https://tests.montychess.org/tests/view/672cc8cc7f02642c6c154e31

Passed LTC:
LLR: 2.95 (-2.94,2.94) <1.00,5.00>
Total: 1094 W: 327 L: 173 D: 594
Ptnml(0-2): 3, 72, 254, 204, 14
https://tests.montychess.org/tests/view/672ccea97f02642c6c154e36