### PR TITLE
New Policy Network: `nn-5e45d73042ed.network`

### DIFF
--- a/src/chess.rs
+++ b/src/chess.rs
@@ -140,14 +140,14 @@ impl ChessState {
         self.stm()
     }
 
-    pub fn get_policy_feats(&self, policy: &PolicyNetwork) -> Accumulator<i16, 2048> {
+    pub fn get_policy_feats(&self, policy: &PolicyNetwork) -> Accumulator<i16, 4096> {
         policy.hl(&self.board)
     }
 
     pub fn get_policy(
         &self,
         mov: Move,
-        hl: &Accumulator<i16, 2048>,
+        hl: &Accumulator<i16, 4096>,
         policy: &PolicyNetwork,
     ) -> f32 {
         policy.get(&self.board, &mov, hl)

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -10,7 +10,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const PolicyFileDefaultName: &str = "nn-05417b70e5c3.network";
+pub const PolicyFileDefaultName: &str = "nn-5e45d73042ed.network";
 
 const QA: i16 = 256;
 const QB: i16 = 512;

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -10,13 +10,13 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const PolicyFileDefaultName: &str = "nn-2f9491f0e187.network";
+pub const PolicyFileDefaultName: &str = "nn-05417b70e5c3.network";
 
 const QA: i16 = 256;
 const QB: i16 = 512;
 const FACTOR: i16 = 32;
 
-const L1: usize = 2048;
+const L1: usize = 4096;
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/train/policy/src/bin/quantise.rs
+++ b/train/policy/src/bin/quantise.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, MappedWeights, PolicyNetwork, Unquantise
 
 fn main() {
     let unquantised: MappedWeights<UnquantisedPolicyNetwork> =
-        unsafe { read_into_struct_unchecked("policy001-270.network") };
+        unsafe { read_into_struct_unchecked("policy001-300.network") };
 
     let quantised = unquantised.data.quantise();
 


### PR DESCRIPTION
Increases the policy L1 size from 2048 to 4096. Also includes winning positions in training, and only drops from 1e-3 to 1e-5 over the 300 superbatches to increase convergence.

Passed LTC:
LLR: 2.98 (-2.94,2.94) <0.00,4.00>
Total: 16368 W: 3600 L: 3406 D: 9362
Ptnml(0-2): 143, 1812, 4073, 2020, 136
https://tests.montychess.org/tests/view/672eccc5827253cd763948da

Passed VLTC:
LLR: 2.95 (-2.94,2.94) <1.00,5.00>
Total: 3012 W: 701 L: 554 D: 1757
Ptnml(0-2): 7, 299, 756, 428, 16
https://tests.montychess.org/tests/view/672ed151827253cd7639493c

Bench: 1699266
