### PR TITLE
New Value Network: `nn-785bc0ff98ac.network`

### DIFF
--- a/src/chess.rs
+++ b/src/chess.rs
@@ -159,10 +159,15 @@ impl ChessState {
     }
 
     pub fn get_value(&self, value: &ValueNetwork, _params: &MctsParams) -> i32 {
+        const K: f32 = 400.0;
+        let (win, draw, _) = value.eval(&self.board);
+
+        let score = win + draw / 2.0;
+        let cp = (-K * (1.0 / score.clamp(0.0, 1.0) - 1.0).ln()) as i32;
+        
         #[cfg(not(feature = "datagen"))]
         {
             use consts::Piece;
-            let raw_eval = value.eval(&self.board);
 
             let mut mat = self.piece_count(Piece::KNIGHT) * _params.knight_value()
                 + self.piece_count(Piece::BISHOP) * _params.bishop_value()
@@ -171,11 +176,11 @@ impl ChessState {
 
             mat = _params.material_offset() + mat / _params.material_div1();
 
-            raw_eval * mat / _params.material_div2()
+            cp * mat / _params.material_div2()
         }
 
         #[cfg(feature = "datagen")]
-        value.eval(&self.board)
+        cp
     }
 
     pub fn get_value_wdl(&self, value: &ValueNetwork, params: &MctsParams) -> f32 {

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -164,7 +164,7 @@ impl ChessState {
 
         let score = win + draw / 2.0;
         let cp = (-K * (1.0 / score.clamp(0.0, 1.0) - 1.0).ln()) as i32;
-        
+
         #[cfg(not(feature = "datagen"))]
         {
             use consts::Piece;

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -1,5 +1,3 @@
-use crate::Board;
-
 use super::{accumulator::Accumulator, activation::Activation};
 
 #[repr(C)]
@@ -7,23 +5,6 @@ use super::{accumulator::Accumulator, activation::Activation};
 pub struct Layer<T: Copy, const M: usize, const N: usize> {
     pub weights: [Accumulator<T, N>; M],
     pub biases: Accumulator<T, N>,
-}
-
-impl<const M: usize, const N: usize> Layer<i16, M, N> {
-    pub fn forward(&self, board: &Board) -> Accumulator<i16, N> {
-        let mut count = 0;
-        let mut feats = [0; 32];
-        board.map_value_features(|feat| {
-            feats[count] = feat;
-            count += 1;
-        });
-
-        let mut out = self.biases;
-
-        out.add_multi(&feats[..count], &self.weights);
-
-        out
-    }
 }
 
 impl<const M: usize, const N: usize> Layer<f32, M, N> {

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -7,7 +7,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-faeeffb146fa.network";
+pub const ValueFileDefaultName: &str = "nn-785bc0ff98ac.network";
 
 const QA: i16 = 512;
 const QB: i16 = 1024;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -11,8 +11,6 @@ pub const ValueFileDefaultName: &str = "nn-4587c7cdf848.network";
 
 const QA: i16 = 512;
 const QB: i16 = 1024;
-const SCALE: i32 = 400;
-
 const FACTOR: i16 = 32;
 
 #[repr(C)]
@@ -20,17 +18,44 @@ pub struct ValueNetwork {
     l1: Layer<i16, { 768 * 4 }, 4096>,
     l2: TransposedLayer<i16, 4096, 16>,
     l3: Layer<f32, 16, 128>,
-    l4: Layer<f32, 128, 1>,
+    l4: Layer<f32, 128, 3>,
+    pst: Layer<f32, { 768 * 4 }, 3>,
 }
 
 impl ValueNetwork {
-    pub fn eval(&self, board: &Board) -> i32 {
-        let l2 = self.l1.forward(board);
+    pub fn eval(&self, board: &Board) -> (f32, f32, f32) {
+        let mut pst = self.pst.biases;
+
+        let mut count = 0;
+        let mut feats = [0; 32];
+        board.map_value_features(|feat| {
+            feats[count] = feat;
+            pst.add(&self.pst.weights[feat]);
+            count += 1;
+        });
+
+        let mut l2 = self.l1.biases;
+
+        l2.add_multi(&feats[..count], &self.l1.weights);
+
         let l3 = self.l2.forward_from_i16::<SCReLU, QA, QB, FACTOR>(&l2);
         let l4 = self.l3.forward::<SCReLU>(&l3);
-        let out = self.l4.forward::<SCReLU>(&l4);
+        let mut out = self.l4.forward::<SCReLU>(&l4);
+        out.add(&pst);
 
-        (out.0[0] * SCALE as f32) as i32
+        let mut win = out.0[2];
+        let mut draw = out.0[1];
+        let mut loss = out.0[0];
+
+        let max = win.max(draw).max(loss);
+
+        win = (win - max).exp();
+        draw = (draw - max).exp();
+        loss = (loss - max).exp();
+
+        let sum = win + draw + loss;
+
+        (win / sum, draw / sum, loss / sum)
     }
 }
 
@@ -39,7 +64,8 @@ pub struct UnquantisedValueNetwork {
     l1: Layer<f32, { 768 * 4 }, 4096>,
     l2: Layer<f32, 4096, 16>,
     l3: Layer<f32, 16, 128>,
-    l4: Layer<f32, 128, 1>,
+    l4: Layer<f32, 128, 3>,
+    pst: Layer<f32, { 768 * 4 }, 3>,
 }
 
 impl UnquantisedValueNetwork {
@@ -52,6 +78,7 @@ impl UnquantisedValueNetwork {
 
         quantised.l3 = self.l3;
         quantised.l4 = self.l4;
+        quantised.pst = self.pst;
 
         quantised
     }

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -7,7 +7,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-4587c7cdf848.network";
+pub const ValueFileDefaultName: &str = "nn-faeeffb146fa.network";
 
 const QA: i16 = 512;
 const QB: i16 = 1024;

--- a/train/value/src/bin/quantise.rs
+++ b/train/value/src/bin/quantise.rs
@@ -1,12 +1,12 @@
 use std::io::Write;
 
-use monty::{read_into_struct_unchecked, UnquantisedValueNetwork, ValueNetwork};
+use monty::{read_into_struct_unchecked, MappedWeights, UnquantisedValueNetwork, ValueNetwork};
 
 fn main() {
-    let unquantised: Box<UnquantisedValueNetwork> =
+    let unquantised: MappedWeights<UnquantisedValueNetwork> =
         unsafe { read_into_struct_unchecked("params.bin") };
 
-    let quantised = unquantised.quantise();
+    let quantised = unquantised.data.quantise();
 
     let mut file = std::fs::File::create("quantised.network").unwrap();
 


### PR DESCRIPTION
Implements WDL outputs and PSQT subnet. Trained for 3600SB with LR starting at 1e-3 and exponentially decaying to 5e-7. It was measured that these changes increase training convergence rate and also that LR below 1e-5 is still worth 10+ Elo.

Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,4.00>
Total: 26688 W: 7500 L: 7224 D: 11964
Ptnml(0-2): 703, 3040, 5612, 3256, 733
https://tests.montychess.org/tests/view/67305039827253cd76394cc9

Passed LTC:
LLR: 2.96 (-2.94,2.94) <0.00,4.00>
Total: 7596 W: 1813 L: 1641 D: 4142
Ptnml(0-2): 72, 853, 1786, 1005, 82
https://tests.montychess.org/tests/view/67305017827253cd76394cc4

Bench: 2668172