### PR TITLE
Quantise Policy Output Layer from i16 to i8

### DIFF
--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -98,4 +98,21 @@ impl<const N: usize> Accumulator<f32, N> {
 
         res
     }
+
+    pub fn quantise_i8(&self, qa: i8, warn_limit: f32) -> Accumulator<i8, N> {
+        let mut res = Accumulator([0; N]);
+
+        for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {
+            if j.abs() > warn_limit {
+                println!("WARNING: {j} > {warn_limit}")
+            }
+
+            let unq = j * f32::from(qa);
+            *i = unq as i8;
+
+            assert_eq!(unq.trunc(), f32::from(*i));
+        }
+
+        res
+    }
 }

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -47,6 +47,27 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
 
         dest.biases = self.biases.quantise_i16(qa, warn_limit);
     }
+
+    pub fn quantise_transpose_into_i8(
+        &self,
+        dest: &mut TransposedLayer<i8, M, N>,
+        qa: i8,
+        warn_limit: f32,
+    ) {
+        let mut untrans = vec![Accumulator([0; N]); M];
+
+        for (acc_i, acc_j) in untrans.iter_mut().zip(self.weights.iter()) {
+            *acc_i = acc_j.quantise_i8(qa, warn_limit);
+        }
+
+        for i in 0..N {
+            for (j, row) in untrans.iter().enumerate() {
+                dest.weights[i].0[j] = row.0[i];
+            }
+        }
+
+        dest.biases = self.biases.quantise_i8(qa, warn_limit);
+    }
 }
 
 #[repr(C)]

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -13,7 +13,7 @@ use super::{
 pub const PolicyFileDefaultName: &str = "nn-5e45d73042ed.network";
 
 const QA: i16 = 256;
-const QB: i16 = 512;
+const QB: i8 = 64;
 const FACTOR: i16 = 32;
 
 const L1: usize = 4096;
@@ -22,7 +22,7 @@ const L1: usize = 4096;
 #[derive(Clone, Copy)]
 pub struct PolicyNetwork {
     l1: Layer<i16, { 768 * 4 }, L1>,
-    l2: TransposedLayer<i16, L1, { 1880 * 2 }>,
+    l2: TransposedLayer<i8, L1, { 1880 * 2 }>,
 }
 
 impl PolicyNetwork {
@@ -106,7 +106,7 @@ impl UnquantisedPolicyNetwork {
 
         self.l1.quantise_into_i16(&mut quantised.l1, QA, 1.98);
         self.l2
-            .quantise_transpose_into_i16(&mut quantised.l2, QB, 1.98);
+            .quantise_transpose_into_i8(&mut quantised.l2, QB, 1.98);
 
         quantised
     }

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -10,7 +10,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const PolicyFileDefaultName: &str = "nn-5e45d73042ed.network";
+pub const PolicyFileDefaultName: &str = "nn-52eb9a243ae0.network";
 
 const QA: i16 = 256;
 const QB: i8 = 64;


### PR DESCRIPTION
Reduces time losses at both STC and LTC on high core count workers due to lower bandwidth pressure.

Passed STC:
LLR: 2.96 (-2.94,2.94) <0.00,4.00>
Total: 9536 W: 2436 L: 2238 D: 4862
Ptnml(0-2): 194, 1002, 2225, 1106, 241
https://tests.montychess.org/tests/view/673407e1a7c54f46a81d01e2

Passed LTC:
LLR: 2.96 (-2.94,2.94) <1.00,5.00>
Total: 8310 W: 1803 L: 1620 D: 4887
Ptnml(0-2): 57, 896, 2152, 907, 143
https://tests.montychess.org/tests/view/67340a47a7c54f46a81d01ea

Bench: 2387354
