### PR TITLE
Build Binaries Automatically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+name: Build Binary
+
+on:
+  push:
+    branches:
+      - '**'  # Triggers on all branches
+  pull_request:
+    branches:
+      - '**'  # Triggers on all branches
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Install build dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get update && sudo apt-get install build-essential -y
+
+    - name: Install Make on Windows
+      if: matrix.os == 'windows-latest'
+      run: choco install make
+
+    - name: Run Make
+      run: make

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,32 @@ on:
       - '**'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  create_prerelease:
+    runs-on: ubuntu-latest
+    #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
+      - name: Delete Existing Release
+        shell: bash
+        run: |
+          gh release delete prerelease-latest -y || true
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/prerelease-latest" || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Prerelease
+        shell: bash
+        run: |
+          gh release create prerelease-latest -t "Latest Prerelease Build" -p || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build_and_upload:
+    needs: create_prerelease
+    
+    runs-on: ${{ matrix.os }}
+    
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -69,4 +92,19 @@ jobs:
         else
           echo "Benchmark output matches reference."
         fi
+        
+    - name: Upload Binary to Release
+      shell: bash
+      #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+      run: |
+        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          binary_path="./monty.exe"
+        else
+          binary_path="./monty"
+        fi
+        asset_name="monty-${{ matrix.os }}"
+        cp "$binary_path" "$asset_name"
+        gh release upload prerelease-latest "$asset_name" --clobber
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   create_prerelease:
     runs-on: ubuntu-latest
-    #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+    if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -118,7 +118,7 @@ jobs:
         
     - name: Upload Binary to Release
       shell: bash
-      #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+      if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
       run: |
         if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
           binary_path="./monty.exe"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,11 @@ jobs:
         DATE=$(date +'%Y%m%d')
         SHORT_SHA=$(git rev-parse --short=8 HEAD)
         OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
-        export BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}"
+        if [[ "$OS_NAME" == "windows" ]]; then
+          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}.exe"
+        else
+          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}"
+        fi
         echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
         echo "Binary Name: $BINARY_NAME"
     

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,13 +19,21 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+    
+    - name: Install tac on macOS
+      if: matrix.os == 'macos-latest'
+      run: brew install coreutils
 
     - name: Extract the Bench Reference
       id: benchref
       shell: bash
       run: |
+        tac_cmd="tac"
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          tac_cmd="gtac"  # Use 'gtac' on macOS, provided by coreutils
+        fi
         for hash in $(git rev-list -100 HEAD); do
-          benchref=$(git show -s $hash | tac | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
+          benchref=$(git show -s $hash | $tac_cmd | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
         done
         [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
 
@@ -54,6 +62,7 @@ jobs:
         echo "Current bench output: $bench_output"
         
     - name: Compare Bench Output
+      shell: bash
       run: |
         if [[ "$bench_output" -ne "$benchref" ]]; then
           echo "::warning::Benchmark output for ${{ matrix.os }} ($bench_output) differs from reference ($benchref)"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set Prerelease Name
+        id: prerelease_info
+        run: |
+          DATE=$(date +'%Y%m%d')
+          SHORT_SHA=$(git rev-parse --short=8 HEAD)
+          PRERELEASE_NAME="Monty-dev-${DATE}-${SHORT_SHA}"
+          echo "PRERELEASE_NAME=$PRERELEASE_NAME" >> $GITHUB_ENV
+          echo "Prerelease Name: $PRERELEASE_NAME"
+
       - name: Delete Existing Release
         shell: bash
         run: |
@@ -27,7 +36,7 @@ jobs:
       - name: Create Prerelease
         shell: bash
         run: |
-          gh release create prerelease-latest -t "Latest Prerelease Build" -p || true
+          gh release create prerelease-latest -t "${{ env.PRERELEASE_NAME }}" -p || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build_and_upload:
@@ -42,6 +51,16 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Set Up Environment
+      shell: bash
+      run: |
+        DATE=$(date +'%Y%m%d')
+        SHORT_SHA=$(git rev-parse --short=8 HEAD)
+        OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
+        export BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}"
+        echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
+        echo "Binary Name: $BINARY_NAME"
     
     - name: Install tac on macOS
       if: matrix.os == 'macos-latest'
@@ -103,8 +122,8 @@ jobs:
           binary_path="./monty"
         fi
         asset_name="monty-${{ matrix.os }}"
-        cp "$binary_path" "$asset_name"
-        gh release upload prerelease-latest "$asset_name" --clobber
+        cp "$binary_path" "$BINARY_NAME"
+        gh release upload prerelease-latest "$BINARY_NAME" --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,3 +36,7 @@ jobs:
 
     - name: Run Make
       run: make
+
+    - name: Get Bench
+      run: ./monty bench
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,10 +3,10 @@ name: Build Binary
 on:
   push:
     branches:
-      - '**'  # Triggers on all branches
+      - '**'
   pull_request:
     branches:
-      - '**'  # Triggers on all branches
+      - '**'
 
 jobs:
   build:
@@ -19,6 +19,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Extract the Bench Reference
+      id: benchref
+      shell: bash
+      run: |
+        for hash in $(git rev-list -100 HEAD); do
+          benchref=$(git show -s $hash | tac | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
+        done
+        [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
@@ -34,6 +43,21 @@ jobs:
     - name: Run Make
       run: make
 
-    - name: Get Bench
-      run: ./monty bench
+    - name: Get Bench Output
+      id: bench_output
+      shell: bash
+      run: |
+        full_output=$(./monty bench)
+        echo "$full_output"
+        bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
+        echo "bench_output=$bench_output" >> $GITHUB_ENV
+        echo "Current bench output: $bench_output"
+        
+    - name: Compare Bench Output
+      run: |
+        if [[ "$bench_output" -ne "$benchref" ]]; then
+          echo "::warning::Benchmark output for ${{ matrix.os }} ($bench_output) differs from reference ($benchref)"
+        else
+          echo "Benchmark output matches reference."
+        fi
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,13 +18,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Install build dependencies
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Builds the binaries for Windows, Ubuntu and macOS. Also checks their bench outputs match the commit message (and throws a warning if not).

Based on the master branch of the official-monty/Monty repo, a prerelease is created and the binaries are uploaded. They are named with the OS, date and first 8 characters of the commit SHA. A new prerelease overrides the old one.

No functional change.

Bench: 2387354