### PR TITLE
New Value Network: `nn-68b9a835a698.network`

### DIFF
--- a/src/bin/quantise-value.rs
+++ b/src/bin/quantise-value.rs
@@ -4,7 +4,7 @@ use monty::{read_into_struct_unchecked, MappedWeights, UnquantisedValueNetwork, 
 
 fn main() {
     let unquantised: MappedWeights<UnquantisedValueNetwork> =
-        unsafe { read_into_struct_unchecked("params.bin") };
+        unsafe { read_into_struct_unchecked("raw.bin") };
 
     let quantised = unquantised.data.quantise();
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -2,7 +2,7 @@ use crate::{boxed_and_zeroed, Board};
 
 use super::{
     activation::SCReLU,
-    layer::{Layer, TransposedLayer},
+    layer::{Layer, TransposedLayer}, Accumulator,
 };
 
 // DO NOT MOVE
@@ -13,10 +13,12 @@ const QA: i16 = 512;
 const QB: i16 = 1024;
 const FACTOR: i16 = 32;
 
+const L1: usize = 4096;
+
 #[repr(C)]
 pub struct ValueNetwork {
-    l1: Layer<i16, { 768 * 4 }, 4096>,
-    l2: TransposedLayer<i16, 4096, 16>,
+    l1: Layer<i16, { 768 * 4 }, L1>,
+    l2: TransposedLayer<i16, { L1 / 2 }, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 3>,
     pst: Layer<f32, { 768 * 4 }, 3>,
@@ -38,7 +40,28 @@ impl ValueNetwork {
 
         l2.add_multi(&feats[..count], &self.l1.weights);
 
-        let l3 = self.l2.forward_from_i16::<SCReLU, QA, QB, FACTOR>(&l2);
+        let mut act = [0; L1 / 2];
+
+        for (a, (&i, &j)) in act.iter_mut().zip(l2.0.iter().take(L1 / 2).zip(l2.0.iter().skip(L1 / 2))) {
+            let i = i32::from(i).clamp(0, i32::from(QA));
+            let j = i32::from(j).clamp(0, i32::from(QA));
+            *a = ((i * j) / i32::from(QA / FACTOR)) as i16;
+        }
+
+        let mut fwd = [0; 16];
+
+        for (f, row) in fwd.iter_mut().zip(self.l2.weights.iter()) {
+            for (&a, &w) in act.iter().zip(row.0.iter()) {
+                *f += i32::from(a) * i32::from(w);
+            }
+        }
+
+        let mut l3 = Accumulator([0.0; 16]);
+
+        for (r, (&f, &b)) in l3.0.iter_mut().zip(fwd.iter().zip(self.l2.biases.0.iter())) {
+            *r = (f as f32 / f32::from(QA * FACTOR) + f32::from(b)) / f32::from(QB);
+        }
+
         let l4 = self.l3.forward::<SCReLU>(&l3);
         let mut out = self.l4.forward::<SCReLU>(&l4);
         out.add(&pst);
@@ -62,7 +85,7 @@ impl ValueNetwork {
 #[repr(C)]
 pub struct UnquantisedValueNetwork {
     l1: Layer<f32, { 768 * 4 }, 4096>,
-    l2: Layer<f32, 4096, 16>,
+    l2: Layer<f32, 2048, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 3>,
     pst: Layer<f32, { 768 * 4 }, 3>,

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -2,7 +2,8 @@ use crate::{boxed_and_zeroed, Board};
 
 use super::{
     activation::SCReLU,
-    layer::{Layer, TransposedLayer}, Accumulator,
+    layer::{Layer, TransposedLayer},
+    Accumulator,
 };
 
 // DO NOT MOVE
@@ -42,7 +43,10 @@ impl ValueNetwork {
 
         let mut act = [0; L1 / 2];
 
-        for (a, (&i, &j)) in act.iter_mut().zip(l2.0.iter().take(L1 / 2).zip(l2.0.iter().skip(L1 / 2))) {
+        for (a, (&i, &j)) in act
+            .iter_mut()
+            .zip(l2.0.iter().take(L1 / 2).zip(l2.0.iter().skip(L1 / 2)))
+        {
             let i = i32::from(i).clamp(0, i32::from(QA));
             let j = i32::from(j).clamp(0, i32::from(QA));
             *a = ((i * j) / i32::from(QA / FACTOR)) as i16;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -7,13 +7,13 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const ValueFileDefaultName: &str = "nn-785bc0ff98ac.network";
+pub const ValueFileDefaultName: &str = "nn-68b9a835a698.network";
 
 const QA: i16 = 512;
 const QB: i16 = 1024;
 const FACTOR: i16 = 32;
 
-const L1: usize = 4096;
+const L1: usize = 6144;
 
 #[repr(C)]
 pub struct ValueNetwork {
@@ -84,8 +84,8 @@ impl ValueNetwork {
 
 #[repr(C)]
 pub struct UnquantisedValueNetwork {
-    l1: Layer<f32, { 768 * 4 }, 4096>,
-    l2: Layer<f32, 2048, 16>,
+    l1: Layer<f32, { 768 * 4 }, 6144>,
+    l2: Layer<f32, 3072, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 3>,
     pst: Layer<f32, { 768 * 4 }, 3>,


### PR DESCRIPTION
Makes Value L1 pairwise and 6144 instead of 4096 neurons.

Passed STC:
LLR: 3.66 (-2.94,2.94) <0.00,4.00>
Total: 6240 W: 1737 L: 1509 D: 2994
Ptnml(0-2): 116, 685, 1316, 861, 142
https://tests.montychess.org/tests/view/67354607a7c54f46a81d02ab

Passed LTC:
LLR: 3.44 (-2.94,2.94) <1.00,5.00>
Total: 2634 W: 719 L: 539 D: 1376
Ptnml(0-2): 16, 237, 651, 377, 36
https://tests.montychess.org/tests/view/6735471aa7c54f46a81d02ae

Bench: 2432432