### PR TITLE
New Policy Network: `nn-9f4927501e11.network`

### DIFF
--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -99,7 +99,7 @@ impl<const N: usize> Accumulator<f32, N> {
         res
     }
 
-    pub fn quantise_i8(&self, qa: i8, warn_limit: f32) -> Accumulator<i8, N> {
+    pub fn quantise_i8(&self, qa: i16, warn_limit: f32) -> Accumulator<i8, N> {
         let mut res = Accumulator([0; N]);
 
         for (i, &j) in res.0.iter_mut().zip(self.0.iter()) {

--- a/src/networks/layer.rs
+++ b/src/networks/layer.rs
@@ -27,6 +27,14 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
         dest.biases = self.biases.quantise_i16(qa, warn_limit);
     }
 
+    pub fn quantise_into_i8(&self, dest: &mut Layer<i8, M, N>, qa: i16, warn_limit: f32) {
+        for (acc_i, acc_j) in dest.weights.iter_mut().zip(self.weights.iter()) {
+            *acc_i = acc_j.quantise_i8(qa, warn_limit);
+        }
+
+        dest.biases = self.biases.quantise_i8(qa, warn_limit);
+    }
+
     pub fn quantise_transpose_into_i16(
         &self,
         dest: &mut TransposedLayer<i16, M, N>,
@@ -51,7 +59,7 @@ impl<const M: usize, const N: usize> Layer<f32, M, N> {
     pub fn quantise_transpose_into_i8(
         &self,
         dest: &mut TransposedLayer<i8, M, N>,
-        qa: i8,
+        qa: i16,
         warn_limit: f32,
     ) {
         let mut untrans = vec![Accumulator([0; N]); M];

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -10,7 +10,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const PolicyFileDefaultName: &str = "nn-52eb9a243ae0.network";
+pub const PolicyFileDefaultName: &str = "nn-9f4927501e11.network";
 
 const QA: i16 = 128;
 const QB: i16 = 128;


### PR DESCRIPTION
Quantise policy L1 from i16 to i8. This also required retraining a network with stricter weight clippings.

Passed STC:
LLR: 2.92 (-2.94,2.94) <0.00,4.00>
Total: 5440 W: 1452 L: 1273 D: 2715
Ptnml(0-2): 105, 544, 1258, 693, 120
https://tests.montychess.org/tests/view/6735496ca7c54f46a81d02b7

Passed LTC:
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 8580 W: 1853 L: 1685 D: 5042
Ptnml(0-2): 33, 896, 2270, 1052, 39
https://tests.montychess.org/tests/view/67354b21a7c54f46a81d02c2

Bench: 2808107