### PR TITLE
Add targets to prereleases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,9 +139,6 @@ jobs:
         run: |
           echo "Building for CPU Level: ${{ matrix.cpu_level }}"
           cargo rustc --release --bin monty --features=embed -- -C target-cpu=${{ matrix.cpu_level }}
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            mv target/release/monty target/release/monty.exe
-          fi
           if [[ ! -f "target/release/monty" && ! -f "target/release/monty.exe" ]]; then
             echo "::error::Build failed, binary not found."
             exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   create_prerelease:
     runs-on: ubuntu-latest
-    #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+    if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload Binary to Release
         shell: bash
-        #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+        if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
         run: |
           binary_source="./target/release/monty"
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   create_prerelease:
     runs-on: ubuntu-latest
-    #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+    if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,129 +39,95 @@ jobs:
           gh release create prerelease-latest -t "${{ env.PRERELEASE_NAME }}" -p || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build_and_upload:
     needs: create_prerelease
+    
     runs-on: ${{ matrix.os }}
-
+    
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            arch: x86_64
-            cpu_level: [x86-64-v1, x86-64-v2, x86-64-v3, x86-64-v4]
-          - os: windows-latest
-            arch: x86_64
-            cpu_level: [x86-64-v1, x86-64-v2, x86-64-v3, x86-64-v4]
-          - os: macos-latest
-            arch: x86_64
-            cpu_level: [x86-64-v1, x86-64-v2, x86-64-v3, x86-64-v4]
-          - os: macos-latest
-            arch: aarch64
-            cpu_level: [] # ARM64 does not use x86-64-v1 to v4
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-      - name: Set Up Environment
-        shell: bash
-        run: |
-          DATE=$(date +'%Y%m%d')
-          SHORT_SHA=$(git rev-parse --short=8 HEAD)
-          OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
-          ARCH="${{ matrix.arch }}"
-          CPU_LEVEL="${{ matrix.cpu_level }}"
+    - name: Set Up Environment
+      shell: bash
+      run: |
+        DATE=$(date +'%Y%m%d')
+        SHORT_SHA=$(git rev-parse --short=8 HEAD)
+        OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
+        if [[ "$OS_NAME" == "windows" ]]; then
+          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}.exe"
+        else
+          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}"
+        fi
+        echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
+        echo "Binary Name: $BINARY_NAME"
+    
+    - name: Install tac on macOS
+      if: matrix.os == 'macos-latest'
+      run: brew install coreutils
 
-          if [[ -n "$CPU_LEVEL" ]]; then
-            BINARY_NAME="Monty-${OS_NAME}-${CPU_LEVEL}-dev-${DATE}-${SHORT_SHA}"
-          else
-            BINARY_NAME="Monty-${OS_NAME}-${ARCH}-dev-${DATE}-${SHORT_SHA}"
-          fi
+    - name: Extract the Bench Reference
+      id: benchref
+      shell: bash
+      run: |
+        tac_cmd="tac"
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          tac_cmd="gtac"  # Use 'gtac' on macOS, provided by coreutils
+        fi
+        for hash in $(git rev-list -100 HEAD); do
+          benchref=$(git show -s $hash | $tac_cmd | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
+        done
+        [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
 
-          if [[ "$OS_NAME" == "windows" ]]; then
-            BINARY_NAME="${BINARY_NAME}.exe"
-          fi
+    - name: Set up Rust
+      uses: dtolnay/rust-toolchain@stable
 
-          echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
-          echo "Binary Name: $BINARY_NAME"
+    - name: Install build dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get update && sudo apt-get install build-essential -y
 
-      - name: Install tac on macOS
-        if: matrix.os == 'macos-latest'
-        run: brew install coreutils
+    - name: Install Make on Windows
+      if: matrix.os == 'windows-latest'
+      run: choco install make
 
-      - name: Extract the Bench Reference
-        id: benchref
-        shell: bash
-        run: |
-          tac_cmd="tac"
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-            tac_cmd="gtac"  # Use 'gtac' on macOS, provided by coreutils
-          fi
-          for hash in $(git rev-list -100 HEAD); do
-            benchref=$(git show -s $hash | $tac_cmd | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
-          done
-          [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
+    - name: Run Make
+      run: make
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Build Dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install build-essential -y
-
-      - name: Install Make on Windows
-        if: matrix.os == 'windows-latest'
-        run: choco install make
-
-      - name: Build Binary
-        shell: bash
-        run: |
-          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
-            for cpu_level in "${{ matrix.cpu_level[@] }}"; do
-              echo "Building for x86_64 with target CPU level: $cpu_level"
-              cargo rustc --release --bin monty -- -C target-cpu=$cpu_level
-            done
-          elif [[ "${{ matrix.arch }}" == "aarch64" ]]; then
-            echo "Building for aarch64..."
-            cargo build --release --target aarch64-apple-darwin
-          fi
-
-      - name: Get Bench Output
-        id: bench_output
-        shell: bash
-        run: |
-          full_output=$(./monty bench)
-          echo "$full_output"
-          bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
-          echo "bench_output=$bench_output" >> $GITHUB_ENV
-          echo "Current bench output: $bench_output"
-
-      - name: Compare Bench Output
-        shell: bash
-        run: |
-          if [[ "$bench_output" -ne "$benchref" ]]; then
-            echo "::warning::Benchmark output for ${{ matrix.os }} ($bench_output) differs from reference ($benchref)"
-          else
-            echo "Benchmark output matches reference."
-          fi
-
-      - name: Upload Binary to Release
-        shell: bash
-        run: |
-          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
-            for cpu_level in "${{ matrix.cpu_level[@] }}"; do
-              asset_name="$BINARY_NAME"
-              binary_path="target/release/$BINARY_NAME"
-              echo "Uploading $binary_path as $asset_name..."
-              gh release upload prerelease-latest "$binary_path" --clobber --name "$asset_name"
-            done
-          elif [[ "${{ matrix.arch }}" == "aarch64" ]]; then
-            asset_name="$BINARY_NAME"
-            binary_path="target/aarch64-apple-darwin/release/$BINARY_NAME"
-            echo "Uploading $binary_path as $asset_name..."
-            gh release upload prerelease-latest "$binary_path" --clobber --name "$asset_name"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Get Bench Output
+      id: bench_output
+      shell: bash
+      run: |
+        full_output=$(./monty bench)
+        echo "$full_output"
+        bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
+        echo "bench_output=$bench_output" >> $GITHUB_ENV
+        echo "Current bench output: $bench_output"
+        
+    - name: Compare Bench Output
+      shell: bash
+      run: |
+        if [[ "$bench_output" -ne "$benchref" ]]; then
+          echo "::warning::Benchmark output for ${{ matrix.os }} ($bench_output) differs from reference ($benchref)"
+        else
+          echo "Benchmark output matches reference."
+        fi
+        
+    - name: Upload Binary to Release
+      shell: bash
+      if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+      run: |
+        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          binary_path="./monty.exe"
+        else
+          binary_path="./monty"
+        fi
+        asset_name="monty-${{ matrix.os }}"
+        cp "$binary_path" "$BINARY_NAME"
+        gh release upload prerelease-latest "$BINARY_NAME" --clobber
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -171,8 +171,8 @@ jobs:
       - name: Compare Bench Output
         shell: bash
         run: |
-          if [[ "$bench_output" -ne "$benchref" ]]; then
-            echo "::warning::Benchmark output for ${{ matrix.os }} (${matrix.cpu_level}) differs from reference ($benchref)"
+          if [[ "$bench_output" -ne "${{ env.benchref }}" ]]; then
+            echo "::warning::Benchmark output for ${{ matrix.os }} (CPU Level: ${{ matrix.cpu_level }}) differs from reference (${{ env.benchref }}): $bench_output"
           else
             echo "Benchmark output matches reference."
           fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,9 @@ jobs:
           - os: macos-latest
             arch: x86_64
             cpu_level: x86-64-v4
+          - os: macos-latest
+            arch: aarch64
+            cpu_level: ""
 
     steps:
       - name: Checkout code
@@ -137,13 +140,26 @@ jobs:
       - name: Build Binary
         shell: bash
         run: |
-          echo "Building for CPU Level: ${{ matrix.cpu_level }}"
-          cargo rustc --release --bin monty --features=embed -- -C target-cpu=${{ matrix.cpu_level }}
-          if [[ ! -f "target/release/monty" && ! -f "target/release/monty.exe" ]]; then
-            echo "::error::Build failed, binary not found."
+          if [[ "${{ matrix.arch }}" == "aarch64" ]]; then
+            cargo rustc --release --bin monty --features=embed --target aarch64-apple-darwin
+            binary_source="target/aarch64-apple-darwin/release/monty"
+          else
+            cargo rustc --release --bin monty --features=embed -- -C target-cpu=${{ matrix.cpu_level }}
+            if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+              binary_source="target/release/monty.exe"
+            else
+              binary_source="target/release/monty"
+            fi
+          fi
+
+          if [[ ! -f "$binary_source" ]]; then
+            echo "::error::Binary not found at $binary_source"
             exit 1
           fi
-          echo "Binary built successfully."
+
+          mv "$binary_source" "target/release/"
+          echo "Binary moved to target/release/"
+
 
       - name: Get Bench Output
         id: bench_output

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -182,8 +182,7 @@ jobs:
         #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
         run: |
           binary_path="./target/release/$BINARY_NAME"
-          asset_name="${BINARY_NAME}"
           echo "Uploading $binary_path as $asset_name..."
-          gh release upload prerelease-latest "$binary_path" --clobber --name "$asset_name"
+          gh release upload prerelease-latest "$binary_path" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,7 +144,7 @@ jobs:
         id: bench_output
         shell: bash
         run: |
-          binary_path="target/release/$BINARY_NAME"
+          binary_path="target/release/monty"
           if [[ ! -f "$binary_path" ]]; then
             echo "::error::Binary not found at $binary_path"
             exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,13 +138,25 @@ jobs:
         shell: bash
         run: |
           echo "Building for CPU Level: ${{ matrix.cpu_level }}"
-          cargo rustc --release --bin monty -- -C target-cpu=${{ matrix.cpu_level }}
+          cargo rustc --release --bin monty --features=embed -- -C target-cpu=${{ matrix.cpu_level }}
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            mv target/release/monty target/release/monty.exe
+          fi
+          if [[ ! -f "target/release/monty" && ! -f "target/release/monty.exe" ]]; then
+            echo "::error::Build failed, binary not found."
+            exit 1
+          fi
+          echo "Binary built successfully."
 
       - name: Get Bench Output
         id: bench_output
         shell: bash
         run: |
-          binary_path="target/release/monty"
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            binary_path="target/release/monty.exe"
+          else
+            binary_path="target/release/monty"
+          fi
           if [[ ! -f "$binary_path" ]]; then
             echo "::error::Binary not found at $binary_path"
             exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,6 +150,12 @@ jobs:
           if [[ "${{ matrix.arch }}" == "aarch64" ]]; then
             cargo rustc --release --bin monty --features=embed --target aarch64-apple-darwin
             binary_source="target/aarch64-apple-darwin/release/monty"
+            binary_target="target/release/monty"
+
+            if [[ "$binary_source" != "$binary_target" ]]; then
+              mv "$binary_source" "$binary_target"
+              echo "Binary moved to $binary_target"
+            fi
           else
             cargo rustc --release --bin monty --features=embed -- -C target-cpu=${{ matrix.cpu_level }}
             if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
@@ -164,13 +170,7 @@ jobs:
             exit 1
           fi
 
-          binary_target="target/release/$BINARY_NAME"
-          if [[ "$binary_source" != "$binary_target" ]]; then
-            mv "$binary_source" "$binary_target"
-            echo "Binary moved to $binary_target"
-          else
-            echo "Binary is already at the target location: $binary_target"
-          fi
+          echo "Binary built successfully: $binary_source"
 
       - name: Get Bench Output
         id: bench_output

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,8 +181,21 @@ jobs:
         shell: bash
         #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
         run: |
+          binary_source="./target/release/monty"
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            binary_source="./target/release/monty.exe"
+          fi
+
+          if [[ ! -f "$binary_source" ]]; then
+            echo "::error::Binary not found at $binary_source"
+            exit 1
+          fi
+
+          mv "$binary_source" "./target/release/$BINARY_NAME"
+
           binary_path="./target/release/$BINARY_NAME"
-          echo "Uploading $binary_path as $asset_name..."
+          echo "Uploading $binary_path as $BINARY_NAME"
           gh release upload prerelease-latest "$binary_path" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,11 +154,6 @@ jobs:
             mv "$binary_source" "$binary_target"
           else
             cargo rustc --release --bin monty --features=embed -- -C target-cpu=${{ matrix.cpu_level }}
-            if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-              binary_source="target/release/monty.exe"
-            else
-              binary_source="target/release/monty"
-            fi
           fi
 
       - name: Get Bench Output
@@ -199,11 +194,6 @@ jobs:
             binary_source="./target/release/monty.exe"
           fi
 
-          if [[ ! -f "$binary_source" ]]; then
-            echo "::error::Binary not found at $binary_source"
-            exit 1
-          fi
-
           mv "$binary_source" "./target/release/$BINARY_NAME"
 
           binary_path="./target/release/$BINARY_NAME"
@@ -211,4 +201,3 @@ jobs:
           gh release upload prerelease-latest "$binary_path" --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   create_prerelease:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+    #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,95 +39,133 @@ jobs:
           gh release create prerelease-latest -t "${{ env.PRERELEASE_NAME }}" -p || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_and_upload:
     needs: create_prerelease
-    
+
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            cpu_level: x86-64-v1
+          - os: ubuntu-latest
+            arch: x86_64
+            cpu_level: x86-64-v2
+          - os: ubuntu-latest
+            arch: x86_64
+            cpu_level: x86-64-v3
+          - os: ubuntu-latest
+            arch: x86_64
+            cpu_level: x86-64-v4
+          - os: windows-latest
+            arch: x86_64
+            cpu_level: x86-64-v1
+          - os: windows-latest
+            arch: x86_64
+            cpu_level: x86-64-v2
+          - os: windows-latest
+            arch: x86_64
+            cpu_level: x86-64-v3
+          - os: windows-latest
+            arch: x86_64
+            cpu_level: x86-64-v4
+          - os: macos-latest
+            arch: x86_64
+            cpu_level: x86-64-v1
+          - os: macos-latest
+            arch: x86_64
+            cpu_level: x86-64-v2
+          - os: macos-latest
+            arch: x86_64
+            cpu_level: x86-64-v3
+          - os: macos-latest
+            arch: x86_64
+            cpu_level: x86-64-v4
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set Up Environment
-      shell: bash
-      run: |
-        DATE=$(date +'%Y%m%d')
-        SHORT_SHA=$(git rev-parse --short=8 HEAD)
-        OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
-        if [[ "$OS_NAME" == "windows" ]]; then
-          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}.exe"
-        else
-          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}"
-        fi
-        echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
-        echo "Binary Name: $BINARY_NAME"
-    
-    - name: Install tac on macOS
-      if: matrix.os == 'macos-latest'
-      run: brew install coreutils
+      - name: Set Up Environment
+        shell: bash
+        run: |
+          DATE=$(date +'%Y%m%d')
+          SHORT_SHA=$(git rev-parse --short=8 HEAD)
+          OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
+          ARCH="${{ matrix.arch }}"
+          CPU_LEVEL="${{ matrix.cpu_level }}"
+          BINARY_NAME="Monty-${OS_NAME}-${CPU_LEVEL}-dev-${DATE}-${SHORT_SHA}"
 
-    - name: Extract the Bench Reference
-      id: benchref
-      shell: bash
-      run: |
-        tac_cmd="tac"
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-          tac_cmd="gtac"  # Use 'gtac' on macOS, provided by coreutils
-        fi
-        for hash in $(git rev-list -100 HEAD); do
-          benchref=$(git show -s $hash | $tac_cmd | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
-        done
-        [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
+          if [[ "$OS_NAME" == "windows" ]]; then
+            BINARY_NAME="${BINARY_NAME}.exe"
+          fi
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
+          echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
+          echo "Binary Name: $BINARY_NAME"
 
-    - name: Install build dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get update && sudo apt-get install build-essential -y
+      - name: Install tac on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install coreutils
 
-    - name: Install Make on Windows
-      if: matrix.os == 'windows-latest'
-      run: choco install make
+      - name: Extract the Bench Reference
+        id: benchref
+        shell: bash
+        run: |
+          tac_cmd="tac"
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            tac_cmd="gtac"  # Use 'gtac' on macOS, provided by coreutils
+          fi
+          for hash in $(git rev-list -100 HEAD); do
+            benchref=$(git show -s $hash | $tac_cmd | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
+          done
+          [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
 
-    - name: Run Make
-      run: make
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Get Bench Output
-      id: bench_output
-      shell: bash
-      run: |
-        full_output=$(./monty bench)
-        echo "$full_output"
-        bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
-        echo "bench_output=$bench_output" >> $GITHUB_ENV
-        echo "Current bench output: $bench_output"
-        
-    - name: Compare Bench Output
-      shell: bash
-      run: |
-        if [[ "$bench_output" -ne "$benchref" ]]; then
-          echo "::warning::Benchmark output for ${{ matrix.os }} ($bench_output) differs from reference ($benchref)"
-        else
-          echo "Benchmark output matches reference."
-        fi
-        
-    - name: Upload Binary to Release
-      shell: bash
-      if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
-      run: |
-        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-          binary_path="./monty.exe"
-        else
-          binary_path="./monty"
-        fi
-        asset_name="monty-${{ matrix.os }}"
-        cp "$binary_path" "$BINARY_NAME"
-        gh release upload prerelease-latest "$BINARY_NAME" --clobber
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install build dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install build-essential -y
 
+      - name: Install Make on Windows
+        if: matrix.os == 'windows-latest'
+        run: choco install make
+
+      - name: Build Binary
+        shell: bash
+        run: |
+          echo "Building for CPU Level: ${{ matrix.cpu_level }}"
+          cargo rustc --release --bin monty -- -C target-cpu=${{ matrix.cpu_level }}
+
+      - name: Get Bench Output
+        id: bench_output
+        shell: bash
+        run: |
+          full_output=$(./monty bench)
+          echo "$full_output"
+          bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
+          echo "bench_output=$bench_output" >> $GITHUB_ENV
+          echo "Current bench output: $bench_output"
+
+      - name: Compare Bench Output
+        shell: bash
+        run: |
+          if [[ "$bench_output" -ne "$benchref" ]]; then
+            echo "::warning::Benchmark output for ${{ matrix.os }} (${matrix.cpu_level}) differs from reference ($benchref)"
+          else
+            echo "Benchmark output matches reference."
+          fi
+
+      - name: Upload Binary to Release
+        shell: bash
+        #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+        run: |
+          binary_path="./target/release/$BINARY_NAME"
+          asset_name="${BINARY_NAME}"
+          echo "Uploading $binary_path as $asset_name..."
+          gh release upload prerelease-latest "$binary_path" --clobber --name "$asset_name"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -151,11 +151,7 @@ jobs:
             cargo rustc --release --bin monty --features=embed --target aarch64-apple-darwin
             binary_source="target/aarch64-apple-darwin/release/monty"
             binary_target="target/release/monty"
-
-            if [[ "$binary_source" != "$binary_target" ]]; then
-              mv "$binary_source" "$binary_target"
-              echo "Binary moved to $binary_target"
-            fi
+            mv "$binary_source" "$binary_target"
           else
             cargo rustc --release --bin monty --features=embed -- -C target-cpu=${{ matrix.cpu_level }}
             if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
@@ -164,13 +160,6 @@ jobs:
               binary_source="target/release/monty"
             fi
           fi
-
-          if [[ ! -f "$binary_source" ]]; then
-            echo "::error::Binary not found at $binary_source"
-            exit 1
-          fi
-
-          echo "Binary built successfully: $binary_source"
 
       - name: Get Bench Output
         id: bench_output

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,7 +144,13 @@ jobs:
         id: bench_output
         shell: bash
         run: |
-          full_output=$(./monty bench)
+          binary_path="target/release/$BINARY_NAME"
+          if [[ ! -f "$binary_path" ]]; then
+            echo "::error::Binary not found at $binary_path"
+            exit 1
+          fi
+          echo "Running benchmarks with $binary_path"
+          full_output=$("$binary_path" bench)
           echo "$full_output"
           bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
           echo "bench_output=$bench_output" >> $GITHUB_ENV

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,7 +100,14 @@ jobs:
           OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
           ARCH="${{ matrix.arch }}"
           CPU_LEVEL="${{ matrix.cpu_level }}"
-          BINARY_NAME="Monty-${OS_NAME}-${CPU_LEVEL}-dev-${DATE}-${SHORT_SHA}"
+          
+          if [[ -z "$CPU_LEVEL" ]]; then
+            IDENTIFIER="$ARCH"
+          else
+            IDENTIFIER="$CPU_LEVEL"
+          fi
+          
+          BINARY_NAME="Monty-${OS_NAME}-${IDENTIFIER}-dev-${DATE}-${SHORT_SHA}"
 
           if [[ "$OS_NAME" == "windows" ]]; then
             BINARY_NAME="${BINARY_NAME}.exe"
@@ -157,9 +164,13 @@ jobs:
             exit 1
           fi
 
-          mv "$binary_source" "target/release/"
-          echo "Binary moved to target/release/"
-
+          binary_target="target/release/$BINARY_NAME"
+          if [[ "$binary_source" != "$binary_target" ]]; then
+            mv "$binary_source" "$binary_target"
+            echo "Binary moved to $binary_target"
+          else
+            echo "Binary is already at the target location: $binary_target"
+          fi
 
       - name: Get Bench Output
         id: bench_output

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x86_64
-            cpu_level: x86-64-v1
+            cpu_level: x86-64
           - os: ubuntu-latest
             arch: x86_64
             cpu_level: x86-64-v2
@@ -62,7 +62,7 @@ jobs:
             cpu_level: x86-64-v4
           - os: windows-latest
             arch: x86_64
-            cpu_level: x86-64-v1
+            cpu_level: x86-64
           - os: windows-latest
             arch: x86_64
             cpu_level: x86-64-v2
@@ -74,7 +74,7 @@ jobs:
             cpu_level: x86-64-v4
           - os: macos-latest
             arch: x86_64
-            cpu_level: x86-64-v1
+            cpu_level: x86-64
           - os: macos-latest
             arch: x86_64
             cpu_level: x86-64-v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   create_prerelease:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
+    #if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,95 +39,129 @@ jobs:
           gh release create prerelease-latest -t "${{ env.PRERELEASE_NAME }}" -p || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build_and_upload:
     needs: create_prerelease
-    
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            cpu_level: [x86-64-v1, x86-64-v2, x86-64-v3, x86-64-v4]
+          - os: windows-latest
+            arch: x86_64
+            cpu_level: [x86-64-v1, x86-64-v2, x86-64-v3, x86-64-v4]
+          - os: macos-latest
+            arch: x86_64
+            cpu_level: [x86-64-v1, x86-64-v2, x86-64-v3, x86-64-v4]
+          - os: macos-latest
+            arch: aarch64
+            cpu_level: [] # ARM64 does not use x86-64-v1 to v4
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set Up Environment
-      shell: bash
-      run: |
-        DATE=$(date +'%Y%m%d')
-        SHORT_SHA=$(git rev-parse --short=8 HEAD)
-        OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
-        if [[ "$OS_NAME" == "windows" ]]; then
-          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}.exe"
-        else
-          BINARY_NAME="Monty-${OS_NAME}-dev-${DATE}-${SHORT_SHA}"
-        fi
-        echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
-        echo "Binary Name: $BINARY_NAME"
-    
-    - name: Install tac on macOS
-      if: matrix.os == 'macos-latest'
-      run: brew install coreutils
+      - name: Set Up Environment
+        shell: bash
+        run: |
+          DATE=$(date +'%Y%m%d')
+          SHORT_SHA=$(git rev-parse --short=8 HEAD)
+          OS_NAME=$(echo "${{ matrix.os }}" | cut -d'-' -f1)
+          ARCH="${{ matrix.arch }}"
+          CPU_LEVEL="${{ matrix.cpu_level }}"
 
-    - name: Extract the Bench Reference
-      id: benchref
-      shell: bash
-      run: |
-        tac_cmd="tac"
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-          tac_cmd="gtac"  # Use 'gtac' on macOS, provided by coreutils
-        fi
-        for hash in $(git rev-list -100 HEAD); do
-          benchref=$(git show -s $hash | $tac_cmd | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
-        done
-        [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
+          if [[ -n "$CPU_LEVEL" ]]; then
+            BINARY_NAME="Monty-${OS_NAME}-${CPU_LEVEL}-dev-${DATE}-${SHORT_SHA}"
+          else
+            BINARY_NAME="Monty-${OS_NAME}-${ARCH}-dev-${DATE}-${SHORT_SHA}"
+          fi
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
+          if [[ "$OS_NAME" == "windows" ]]; then
+            BINARY_NAME="${BINARY_NAME}.exe"
+          fi
 
-    - name: Install build dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get update && sudo apt-get install build-essential -y
+          echo "BINARY_NAME=$BINARY_NAME" >> $GITHUB_ENV
+          echo "Binary Name: $BINARY_NAME"
 
-    - name: Install Make on Windows
-      if: matrix.os == 'windows-latest'
-      run: choco install make
+      - name: Install tac on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install coreutils
 
-    - name: Run Make
-      run: make
+      - name: Extract the Bench Reference
+        id: benchref
+        shell: bash
+        run: |
+          tac_cmd="tac"
+          if [[ "$OSTYPE" == "darwin"* ]]; then
+            tac_cmd="gtac"  # Use 'gtac' on macOS, provided by coreutils
+          fi
+          for hash in $(git rev-list -100 HEAD); do
+            benchref=$(git show -s $hash | $tac_cmd | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
+          done
+          [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "Reference bench: $benchref" || echo "No bench found"
 
-    - name: Get Bench Output
-      id: bench_output
-      shell: bash
-      run: |
-        full_output=$(./monty bench)
-        echo "$full_output"
-        bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
-        echo "bench_output=$bench_output" >> $GITHUB_ENV
-        echo "Current bench output: $bench_output"
-        
-    - name: Compare Bench Output
-      shell: bash
-      run: |
-        if [[ "$bench_output" -ne "$benchref" ]]; then
-          echo "::warning::Benchmark output for ${{ matrix.os }} ($bench_output) differs from reference ($benchref)"
-        else
-          echo "Benchmark output matches reference."
-        fi
-        
-    - name: Upload Binary to Release
-      shell: bash
-      if: github.ref == 'refs/heads/master' && github.repository == 'official-monty/Monty'
-      run: |
-        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-          binary_path="./monty.exe"
-        else
-          binary_path="./monty"
-        fi
-        asset_name="monty-${{ matrix.os }}"
-        cp "$binary_path" "$BINARY_NAME"
-        gh release upload prerelease-latest "$BINARY_NAME" --clobber
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Build Dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install build-essential -y
+
+      - name: Install Make on Windows
+        if: matrix.os == 'windows-latest'
+        run: choco install make
+
+      - name: Build Binary
+        shell: bash
+        run: |
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            for cpu_level in "${{ matrix.cpu_level[@] }}"; do
+              echo "Building for x86_64 with target CPU level: $cpu_level"
+              cargo rustc --release --bin monty -- -C target-cpu=$cpu_level
+            done
+          elif [[ "${{ matrix.arch }}" == "aarch64" ]]; then
+            echo "Building for aarch64..."
+            cargo build --release --target aarch64-apple-darwin
+          fi
+
+      - name: Get Bench Output
+        id: bench_output
+        shell: bash
+        run: |
+          full_output=$(./monty bench)
+          echo "$full_output"
+          bench_output=$(echo "$full_output" | grep -o -E '[0-9]+' | head -n 1)
+          echo "bench_output=$bench_output" >> $GITHUB_ENV
+          echo "Current bench output: $bench_output"
+
+      - name: Compare Bench Output
+        shell: bash
+        run: |
+          if [[ "$bench_output" -ne "$benchref" ]]; then
+            echo "::warning::Benchmark output for ${{ matrix.os }} ($bench_output) differs from reference ($benchref)"
+          else
+            echo "Benchmark output matches reference."
+          fi
+
+      - name: Upload Binary to Release
+        shell: bash
+        run: |
+          if [[ "${{ matrix.arch }}" == "x86_64" ]]; then
+            for cpu_level in "${{ matrix.cpu_level[@] }}"; do
+              asset_name="$BINARY_NAME"
+              binary_path="target/release/$BINARY_NAME"
+              echo "Uploading $binary_path as $asset_name..."
+              gh release upload prerelease-latest "$binary_path" --clobber --name "$asset_name"
+            done
+          elif [[ "${{ matrix.arch }}" == "aarch64" ]]; then
+            asset_name="$BINARY_NAME"
+            binary_path="target/aarch64-apple-darwin/release/$BINARY_NAME"
+            echo "Uploading $binary_path as $asset_name..."
+            gh release upload prerelease-latest "$binary_path" --clobber --name "$asset_name"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -22,8 +22,6 @@ jobs:
     steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable
-          with:
-            component: clippy
         - run: cargo clippy -- -D warnings
         - run: cargo clippy --package datagen -- -D warnings
 
@@ -33,6 +31,4 @@ jobs:
     steps:
         - uses: actions/checkout@v4
         - uses: dtolnay/rust-toolchain@stable
-          with:
-            component: rustfmt
         - run: cargo fmt --all -- --check


### PR DESCRIPTION
Targets are x86-64 v1-4 for all of MacOS, Ubuntu and Windows, as well as aarch64 (ARM64) for MacOS.

No functional change.

Bench: 3686348