### PR TITLE
New Policy Network: `nn-658ca1d47406.network`

### DIFF
--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -10,13 +10,13 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals)]
-pub const PolicyFileDefaultName: &str = "nn-6764ee301f3e.network";
+pub const PolicyFileDefaultName: &str = "nn-658ca1d47406.network";
 
 const QA: i16 = 128;
 const QB: i16 = 128;
 const FACTOR: i16 = 32;
 
-pub const L1: usize = 6144;
+pub const L1: usize = 12288;
 
 #[repr(C)]
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Change L1 size from 6144 to 12288.

STC Elo Estimate:
Elo: -37.95 ± 6.0 (95%) LOS: 0.0%
Total: 5000 W: 964 L: 1508 D: 2528
Ptnml(0-2): 152, 766, 1103, 432, 47
nElo: -61.72 ± 9.8 (95%) PairsRatio: 0.52

Passed VVLTC:
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 28204 W: 5583 L: 5338 D: 17283
Ptnml(0-2): 49, 3078, 7613, 3303, 59
https://tests.montychess.org/tests/view/673aac5e1869a4c57c0d13a5

Bench: 4501845