### PR TITLE
Modify Base PST

### DIFF
--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -63,7 +63,7 @@ impl SearchHelpers {
         let scalar = q - q.min(params.winning_pst_threshold());
         let t = scalar / (1.0 - params.winning_pst_threshold());
         let base_pst = ((depth as f32) - 0.34).powf(-1.8) + 0.9;
-        base_pst + (params.winning_pst_max() - 1.0) * t
+        base_pst + (params.winning_pst_max() - base_pst) * t
     }
 
     /// First Play Urgency

--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -59,11 +59,11 @@ impl SearchHelpers {
     }
 
     /// Common depth PST
-    pub fn get_pst(q: f32, params: &MctsParams) -> f32 {
+    pub fn get_pst(depth: usize, q: f32, params: &MctsParams) -> f32 {
         let scalar = q - q.min(params.winning_pst_threshold());
         let t = scalar / (1.0 - params.winning_pst_threshold());
-        1.0 + params.base_pst_adjustment()
-            + (params.winning_pst_max() - (1.0 + params.base_pst_adjustment())) * t
+        let base_pst = ((depth as f32) - 0.34).powf(-1.8) + 0.9;
+        base_pst + (params.winning_pst_max() - base_pst) * t
     }
 
     /// First Play Urgency

--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -62,7 +62,7 @@ impl SearchHelpers {
     pub fn get_pst(depth: usize, q: f32, params: &MctsParams) -> f32 {
         let scalar = q - q.min(params.winning_pst_threshold());
         let t = scalar / (1.0 - params.winning_pst_threshold());
-        let base_pst = ((depth as f32) - 0.34).powf(-1.8) + 0.9;
+        let base_pst = 1.0 - params.base_pst_adjustment()+ ((depth as f32) - params.root_pst_adjustment()).powf(- params.depth_pst_adjustment());
         base_pst + (params.winning_pst_max() - base_pst) * t
     }
 

--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -62,7 +62,8 @@ impl SearchHelpers {
     pub fn get_pst(depth: usize, q: f32, params: &MctsParams) -> f32 {
         let scalar = q - q.min(params.winning_pst_threshold());
         let t = scalar / (1.0 - params.winning_pst_threshold());
-        let base_pst = 1.0 - params.base_pst_adjustment()+ ((depth as f32) - params.root_pst_adjustment()).powf(- params.depth_pst_adjustment());
+        let base_pst = 1.0 - params.base_pst_adjustment()
+            + ((depth as f32) - params.root_pst_adjustment()).powf(-params.depth_pst_adjustment());
         base_pst + (params.winning_pst_max() - base_pst) * t
     }
 

--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -63,7 +63,7 @@ impl SearchHelpers {
         let scalar = q - q.min(params.winning_pst_threshold());
         let t = scalar / (1.0 - params.winning_pst_threshold());
         let base_pst = ((depth as f32) - 0.34).powf(-1.8) + 0.9;
-        base_pst + (params.winning_pst_max() - base_pst) * t
+        base_pst + (params.winning_pst_max() - 1.0) * t
     }
 
     /// First Play Urgency

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -130,11 +130,11 @@ macro_rules! make_mcts_params {
 }
 
 make_mcts_params! {
-    root_pst: f32 = 3.102, 1.0, 10.0, 0.4, 0.002;
-    depth_2_pst_adjustment: f32 = 0.23, 1.0, 10.0, 0.025, 0.002;
+    root_pst_adjustment: f32 = 0.34, 0.01, 1.0, 0.034, 0.002;
+    depth_pst_adjustment: f32 = 1.8, 0.1, 10.0, 0.018, 0.002;
     winning_pst_threshold: f32 = 0.603, 0.0, 1.0, 0.05, 0.002;
     winning_pst_max: f32 = 1.615, 0.1, 10.0, 0.1, 0.002;
-    base_pst_adjustment: f32 = -0.05, 0.1, 10.0, 0.005, 0.002;
+    base_pst_adjustment: f32 = 0.1, 0.01, 1.0, 0.01, 0.002;
     root_cpuct: f32 = 0.422, 0.1, 5.0, 0.065, 0.002;
     cpuct: f32 = 0.269, 0.1, 5.0, 0.065, 0.002;
     cpuct_var_weight: f32 = 0.808, 0.0, 2.0, 0.085, 0.002;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -181,12 +181,7 @@ impl Tree {
 
         let new_ptr = self.tree[self.half()].reserve_nodes(actions.len())?;
 
-        let pst = match depth {
-            0 => unreachable!(),
-            1 => params.root_pst(),
-            2 => 1.0 + params.depth_2_pst_adjustment(),
-            3.. => SearchHelpers::get_pst(self[node_ptr].q(), params),
-        };
+        let pst = SearchHelpers::get_pst(depth, self[node_ptr].q(), params);
 
         let mut total = 0.0;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -233,12 +233,7 @@ impl Tree {
             max = max.max(policy);
         }
 
-        let pst = match depth {
-            0 => unreachable!(),
-            1 => params.root_pst(),
-            2 => 1.0 + params.depth_2_pst_adjustment(),
-            3.. => unreachable!(),
-        };
+        let pst = SearchHelpers::get_pst(depth.into(), self[node_ptr].q(), params);
 
         let mut total = 0.0;
 


### PR DESCRIPTION
Decay base pst with depth using a formula instead of root and depth 2 values.

Passed STC:
LLR: 3.76 (-2.94,2.94) <0.00,4.00>
Total: 68256 W: 17053 L: 16615 D: 34588
Ptnml(0-2): 1045, 8100, 15567, 8204, 1212
https://tests.montychess.org/tests/view/6763062c1678cfe6b826241f

Passed LTC:
LLR: 3.41 (-2.94,2.94) <1.00,5.00>
Total: 48372 W: 10571 L: 10187 D: 27614
Ptnml(0-2): 309, 5530, 12171, 5820, 356
https://tests.montychess.org/tests/view/67630a031678cfe6b8262475

Bench: 2078051