### PR TITLE
Thread scaling improvement + Change move overhead behaviour

### DIFF
--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -148,7 +148,7 @@ impl<'a> DatagenThread<'a> {
             } else {
                 let mut dist = Vec::new();
 
-                let actions = { *tree[tree.root_node()].actions() };
+                let actions = tree[tree.root_node()].actions();
 
                 for action in 0..tree[tree.root_node()].num_actions() {
                     let node = &tree[actions + action];

--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -153,7 +153,7 @@ impl<'a> DatagenThread<'a> {
                 for action in 0..tree[tree.root_node()].num_actions() {
                     let node = &tree[actions + action];
                     let mov = montyformat::chess::Move::from(u16::from(node.parent_move()));
-                    dist.push((mov, node.visits() as u32));
+                    dist.push((mov, node.visits()));
                 }
 
                 assert_eq!(root_count, dist.len());

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -268,7 +268,7 @@ impl<'a> Searcher<'a> {
             self.tree
                 .relabel_policy(node, pos, self.params, self.policy, 1);
 
-            let first_child_ptr = { *self.tree[node].actions() };
+            let first_child_ptr = self.tree[node].actions();
 
             for action in 0..self.tree[node].num_actions() {
                 let ptr = first_child_ptr + action;
@@ -395,7 +395,7 @@ impl<'a> Searcher<'a> {
 
     fn get_best_action(&self, node: NodePtr) -> (NodePtr, Move, f32) {
         let idx = self.tree.get_best_child(node);
-        let ptr = *self.tree[node].actions() + idx;
+        let ptr = self.tree[node].actions() + idx;
         let child = &self.tree[ptr];
         (ptr, child.parent_move(), child.q())
     }
@@ -413,7 +413,7 @@ impl<'a> Searcher<'a> {
     }
 
     pub fn display_moves(&self) {
-        let first_child_ptr = { *self.tree[self.tree.root_node()].actions() };
+        let first_child_ptr = self.tree[self.tree.root_node()].actions();
         for action in 0..self.tree[self.tree.root_node()].num_actions() {
             let child = &self.tree[first_child_ptr + action];
             let mov = self

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -338,7 +338,14 @@ impl<'a> Searcher<'a> {
         (mov, q)
     }
 
-    fn search_report(&self, depth: usize, seldepth: usize, timer: &Instant, nodes: usize, iters: usize) {
+    fn search_report(
+        &self,
+        depth: usize,
+        seldepth: usize,
+        timer: &Instant,
+        nodes: usize,
+        iters: usize,
+    ) {
         print!("info depth {depth} seldepth {seldepth} ");
         let (pv_line, score) = self.get_pv(depth);
 
@@ -351,7 +358,11 @@ impl<'a> Searcher<'a> {
             print!("score cp {cp:.0} ");
         }
 
-        let nodes = if REPORT_ITERS.load(Ordering::Relaxed) { iters } else { nodes };
+        let nodes = if REPORT_ITERS.load(Ordering::Relaxed) {
+            iters
+        } else {
+            nodes
+        };
         let elapsed = timer.elapsed();
         let nps = nodes as f32 / elapsed.as_secs_f32();
         let ms = elapsed.as_millis();

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -45,8 +45,7 @@ pub fn perform_one(
         // select action to take via PUCT
         let action = pick_action(searcher, ptr, node);
 
-        let first_child_ptr = { *node.actions() };
-        let child_ptr = first_child_ptr + action;
+        let child_ptr = node.actions() + action;
 
         let mov = tree[child_ptr].parent_move();
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -75,7 +75,7 @@ impl Tree {
     }
 
     fn copy_node_across(&self, from: NodePtr, to: NodePtr) {
-        if from != to {
+        if from == to {
             return;
         }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -8,7 +8,9 @@ use hash::{HashEntry, HashTable};
 pub use node::{Node, NodePtr};
 
 use std::{
-    mem::MaybeUninit, sync::atomic::{AtomicBool, Ordering}, time::Instant
+    mem::MaybeUninit,
+    sync::atomic::{AtomicBool, Ordering},
+    time::Instant,
 };
 
 use crate::{

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -182,13 +182,11 @@ impl Tree {
             return Some(());
         }
 
-        let feats = pos.get_policy_feats(policy);
         let mut max = f32::NEG_INFINITY;
         let mut moves = [const { MaybeUninit::uninit() }; 256];
         let mut count = 0;
 
-        pos.map_legal_moves(|mov| {
-            let policy = pos.get_policy(mov, &feats, policy);
+        pos.map_moves_with_policies(policy, |mov, policy| {
             moves[count].write((mov, policy));
             count += 1;
             max = max.max(policy);
@@ -235,7 +233,7 @@ impl Tree {
         policy: &PolicyNetwork,
         depth: u8,
     ) {
-        let feats = pos.get_policy_feats(policy);
+        let hl = pos.get_policy_hl(policy);
         let mut max = f32::NEG_INFINITY;
 
         let mut policies = Vec::new();
@@ -246,7 +244,7 @@ impl Tree {
 
         for action in 0..num_actions {
             let mov = self[actions_ptr + action].parent_move();
-            let policy = pos.get_policy(mov, &feats, policy);
+            let policy = pos.get_policy(mov, &hl, policy);
 
             policies.push(policy);
             max = max.max(policy);

--- a/src/tree/lock.rs
+++ b/src/tree/lock.rs
@@ -30,7 +30,10 @@ impl WriteGuard<'_> {
 
 impl CustomLock {
     pub fn new(val: NodePtr) -> Self {
-        Self { value: AtomicU32::new(val.inner()), write_locked: AtomicBool::new(false) }
+        Self {
+            value: AtomicU32::new(val.inner()),
+            write_locked: AtomicBool::new(false),
+        }
     }
 
     pub fn read(&self) -> NodePtr {
@@ -42,7 +45,11 @@ impl CustomLock {
     }
 
     pub fn write(&self) -> WriteGuard<'_> {
-        while self.write_locked.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
+        while self
+            .write_locked
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
             std::hint::spin_loop();
         }
 

--- a/src/tree/lock.rs
+++ b/src/tree/lock.rs
@@ -1,0 +1,51 @@
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use super::NodePtr;
+
+#[derive(Debug)]
+pub struct CustomLock {
+    value: AtomicU32,
+    write_locked: AtomicBool,
+}
+
+pub struct WriteGuard<'a> {
+    lock: &'a CustomLock,
+}
+
+impl Drop for WriteGuard<'_> {
+    fn drop(&mut self) {
+        self.lock.write_locked.store(false, Ordering::SeqCst);
+    }
+}
+
+impl WriteGuard<'_> {
+    pub fn val(&self) -> NodePtr {
+        NodePtr::from_raw(self.lock.value.load(Ordering::SeqCst))
+    }
+
+    pub fn store(&self, val: NodePtr) {
+        self.lock.value.store(val.inner(), Ordering::SeqCst)
+    }
+}
+
+impl CustomLock {
+    pub fn new(val: NodePtr) -> Self {
+        Self { value: AtomicU32::new(val.inner()), write_locked: AtomicBool::new(false) }
+    }
+
+    pub fn read(&self) -> NodePtr {
+        while self.write_locked.load(Ordering::SeqCst) {
+            std::hint::spin_loop();
+        }
+
+        NodePtr::from_raw(self.value.load(Ordering::SeqCst))
+    }
+
+    pub fn write(&self) -> WriteGuard<'_> {
+        while self.write_locked.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
+            std::hint::spin_loop();
+        }
+
+        WriteGuard { lock: self }
+    }
+}

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,6 +1,6 @@
 use std::{
     ops::Add,
-    sync::atomic::{AtomicI32, AtomicU16, AtomicI64, AtomicU8, Ordering},
+    sync::atomic::{AtomicU32, AtomicU16, AtomicU64, AtomicU8, Ordering},
 };
 
 use crate::chess::{GameState, Move};
@@ -56,9 +56,9 @@ pub struct Node {
     threads: AtomicU16,
     mov: AtomicU16,
     policy: AtomicU16,
-    visits: AtomicI32,
-    sum_q: AtomicI64,
-    sum_sq_q: AtomicI64,
+    visits: AtomicU32,
+    sum_q: AtomicU64,
+    sum_sq_q: AtomicU64,
     gini_impurity: AtomicU8,
 }
 
@@ -71,9 +71,9 @@ impl Node {
             threads: AtomicU16::new(0),
             mov: AtomicU16::new(0),
             policy: AtomicU16::new(0),
-            visits: AtomicI32::new(0),
-            sum_q: AtomicI64::new(0),
-            sum_sq_q: AtomicI64::new(0),
+            visits: AtomicU32::new(0),
+            sum_q: AtomicU64::new(0),
+            sum_sq_q: AtomicU64::new(0),
             gini_impurity: AtomicU8::new(0),
         }
     }
@@ -100,7 +100,7 @@ impl Node {
         self.threads.load(Ordering::Relaxed)
     }
 
-    pub fn visits(&self) -> i32 {
+    pub fn visits(&self) -> u32 {
         self.visits.load(Ordering::Relaxed)
     }
 
@@ -113,7 +113,7 @@ impl Node {
 
         let sum_q = self.sum_q.load(Ordering::Relaxed);
 
-        (sum_q / i64::from(visits)) as f64 / f64::from(QUANT)
+        (sum_q / u64::from(visits)) as f64 / f64::from(QUANT)
     }
 
     pub fn q(&self) -> f32 {
@@ -123,7 +123,7 @@ impl Node {
     pub fn sq_q(&self) -> f64 {
         let sum_sq_q = self.sum_sq_q.load(Ordering::Relaxed);
         let visits = self.visits.load(Ordering::Relaxed);
-        (sum_sq_q / i64::from(visits)) as f64 / f64::from(QUANT).powi(2)
+        (sum_sq_q / u64::from(visits)) as f64 / f64::from(QUANT).powi(2)
     }
 
     pub fn var(&self) -> f32 {
@@ -214,11 +214,11 @@ impl Node {
     }
 
     pub fn update(&self, q: f32) -> f32 {
-        let q = (f64::from(q) * f64::from(QUANT)) as i64;
+        let q = (f64::from(q) * f64::from(QUANT)) as u64;
         let old_v = self.visits.fetch_add(1, Ordering::Relaxed);
         let old_q = self.sum_q.fetch_add(q, Ordering::Relaxed);
         self.sum_sq_q.fetch_add(q * q, Ordering::Relaxed);
 
-        (((q + old_q) / i64::from(1 + old_v)) as f64 / f64::from(QUANT)) as f32
+        (((q + old_q) / u64::from(1 + old_v)) as f64 / f64::from(QUANT)) as f32
     }
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,6 +1,6 @@
 use std::{
     ops::Add,
-    sync::atomic::{AtomicU32, AtomicU16, AtomicU64, AtomicU8, Ordering},
+    sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering},
 };
 
 use crate::chess::{GameState, Move};
@@ -176,8 +176,10 @@ impl Node {
     }
 
     pub fn set_gini_impurity(&self, gini_impurity: f32) {
-        self.gini_impurity
-            .store((gini_impurity.clamp(0.0, 1.0) * 255.0) as u8, Ordering::Relaxed);
+        self.gini_impurity.store(
+            (gini_impurity.clamp(0.0, 1.0) * 255.0) as u8,
+            Ordering::Relaxed,
+        );
     }
 
     pub fn clear_actions(&self) {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,6 +1,6 @@
 use crate::{
     chess::{ChessState, Move},
-    mcts::{Limits, MctsParams, SearchHelpers, Searcher},
+    mcts::{Limits, MctsParams, SearchHelpers, Searcher, REPORT_ITERS},
     networks::{PolicyNetwork, ValueNetwork},
     tree::Tree,
 };
@@ -220,6 +220,7 @@ fn preamble() {
     println!("option name UCI_Chess960 type check default false");
     println!("option name MoveOverhead type spin default 40 min 0 max 5000");
     println!("option name report_moves type button");
+    println!("option name report_iters type button");
 
     #[cfg(feature = "tunable")]
     MctsParams::info(MctsParams::default());
@@ -237,6 +238,11 @@ fn setoption(
 ) {
     if let ["setoption", "name", "report_moves"] = commands {
         *report_moves = !*report_moves;
+        return;
+    }
+
+    if let ["setoption", "name", "report_iters"] = commands {
+        REPORT_ITERS.fetch_xor(true, Ordering::Relaxed);
         return;
     }
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -356,7 +356,10 @@ fn go(
     }
 
     // `go wtime <wtime> btime <btime> winc <winc> binc <binc>``
-    if let Some(remaining) = times[pos.stm()] {
+    if let Some(mut remaining) = times[pos.stm()] {
+        // apply move overhead
+        remaining = remaining.saturating_sub(move_overhead as u64).max(10);
+
         let timeman =
             SearchHelpers::get_time(remaining, incs[pos.stm()], root_game_ply, movestogo, params);
 
@@ -368,14 +371,6 @@ fn go(
     if let Some(max) = max_time {
         // if both movetime and increment time controls given, use
         max_time = Some(max_time.unwrap_or(u128::MAX).min(max));
-    }
-
-    // apply move overhead
-    if let Some(t) = opt_time.as_mut() {
-        *t = t.saturating_sub(move_overhead as u128);
-    }
-    if let Some(t) = max_time.as_mut() {
-        *t = t.saturating_sub(move_overhead as u128);
     }
 
     let abort = AtomicBool::new(false);

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -18,7 +18,7 @@ pub fn run(policy: &PolicyNetwork, value: &ValueNetwork) {
     let mut tree = Tree::new_mb(64, 1);
     let mut report_moves = false;
     let mut threads = 1;
-    let mut move_overhead = 40;
+    let mut move_overhead = 400;
 
     let mut stored_message: Option<String> = None;
 
@@ -218,7 +218,7 @@ fn preamble() {
     println!("option name Hash type spin default 64 min 1 max 8192");
     println!("option name Threads type spin default 1 min 1 max 512");
     println!("option name UCI_Chess960 type check default false");
-    println!("option name MoveOverhead type spin default 40 min 0 max 5000");
+    println!("option name MoveOverhead type spin default 400 min 0 max 5000");
     println!("option name report_moves type button");
     println!("option name report_iters type button");
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -86,19 +86,17 @@ pub fn run(policy: &PolicyNetwork, value: &ValueNetwork) {
                 println!("wdl: {:.2}%", 100.0 * pos.get_value_wdl(value, &params));
             }
             "policy" => {
-                let f = pos.get_policy_feats(policy);
                 let mut max = f32::NEG_INFINITY;
                 let mut moves = Vec::new();
 
-                pos.map_legal_moves(|mov| {
+                pos.map_moves_with_policies(policy, |mov, policy| {
                     let s = pos.conv_mov_to_str(mov);
-                    let p = pos.get_policy(mov, &f, policy);
 
-                    if p > max {
-                        max = p;
+                    if policy > max {
+                        max = policy;
                     }
 
-                    moves.push((s, p));
+                    moves.push((s, policy));
                 });
 
                 let mut total = 0.0;


### PR DESCRIPTION
Implements a custom write-lock, eliminates a large number of unnecessary allocations and improves precision for node scores in huge trees (where beforehand f32 would accumulate too much error).

Also changes move overhead behaviour to bank time from the time remaining, rather than from the allocated move time.

Added `report_iters` UCI option to report nodes=iters rather than nodes=cumulative depth.

Passed STC:
LLR: 2.95 (-2.94,2.94) <0.00,4.00>
Total: 12352 W: 3032 L: 2840 D: 6480
Ptnml(0-2): 163, 1363, 2940, 1539, 171
https://tests.montychess.org/tests/view/6811679f1ebd39ca911c73f4

Neutral at STC SMP:
LLR: -2.94 (-2.94,2.94) <1.00,5.00>
Total: 29072 W: 7694 L: 7697 D: 13681
Ptnml(0-2): 563, 3421, 6518, 3524, 510
https://tests.montychess.org/tests/view/681240f81ebd39ca911c7410

Measured significant NPS boost at high thread counts.

Bench: 1799102