### PR TITLE
Improve thread scaling

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -110,7 +110,7 @@ impl<'a> Searcher<'a> {
                 &mut this_depth,
                 thread_id,
             )
-                .is_none()
+            .is_none()
             {
                 return false;
             }
@@ -253,7 +253,8 @@ impl<'a> Searcher<'a> {
             assert_eq!(node, ptr);
 
             self.tree[ptr].clear();
-            self.tree.expand_node(ptr, pos, self.params, self.policy, 1, 0);
+            self.tree
+                .expand_node(ptr, pos, self.params, self.policy, 1, 0);
 
             let root_eval = pos.get_value_wdl(self.value, self.params);
             self.tree[ptr].update(1.0 - root_eval);

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -1,9 +1,11 @@
 mod helpers;
 mod iteration;
 mod params;
+mod search_stats;
 
 pub use helpers::SearchHelpers;
 pub use params::MctsParams;
+pub use search_stats::SearchStats;
 
 use crate::{
     chess::{GameState, Move},
@@ -12,7 +14,7 @@ use crate::{
 };
 
 use std::{
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, Ordering},
     thread,
     time::Instant,
 };
@@ -25,15 +27,6 @@ pub struct Limits {
     pub opt_time: Option<u128>,
     pub max_depth: usize,
     pub max_nodes: usize,
-}
-
-#[derive(Default)]
-pub struct SearchStats {
-    pub total_nodes: AtomicUsize,
-    pub total_iters: AtomicUsize,
-    pub main_iters: AtomicUsize,
-    pub avg_depth: AtomicUsize,
-    pub seldepth: AtomicUsize,
 }
 
 pub struct Searcher<'a> {
@@ -72,8 +65,9 @@ impl<'a> Searcher<'a> {
         best_move_changes: &mut i32,
         previous_score: &mut f32,
         #[cfg(not(feature = "uci-minimal"))] uci_output: bool,
+        thread_id: usize,
     ) {
-        if self.playout_until_full_internal(search_stats, true, || {
+        if self.playout_until_full_internal(search_stats, true, thread_id, || {
             self.check_limits(
                 limits,
                 timer,
@@ -91,14 +85,15 @@ impl<'a> Searcher<'a> {
         }
     }
 
-    fn playout_until_full_worker(&self, search_stats: &SearchStats) {
-        let _ = self.playout_until_full_internal(search_stats, false, || false);
+    fn playout_until_full_worker(&self, search_stats: &SearchStats, thread_id: usize) {
+        let _ = self.playout_until_full_internal(search_stats, false, thread_id, || false);
     }
 
     fn playout_until_full_internal<F>(
         &self,
         search_stats: &SearchStats,
         main_thread: bool,
+        thread_id: usize,
         mut stop: F,
     ) -> bool
     where
@@ -108,22 +103,19 @@ impl<'a> Searcher<'a> {
             let mut pos = self.tree.root_position().clone();
             let mut this_depth = 0;
 
-            if iteration::perform_one(self, &mut pos, self.tree.root_node(), &mut this_depth)
+            if iteration::perform_one(
+                self,
+                &mut pos,
+                self.tree.root_node(),
+                &mut this_depth,
+                thread_id,
+            )
                 .is_none()
             {
                 return false;
             }
 
-            search_stats.total_iters.fetch_add(1, Ordering::Relaxed);
-            search_stats
-                .total_nodes
-                .fetch_add(this_depth, Ordering::Relaxed);
-            search_stats
-                .seldepth
-                .fetch_max(this_depth - 1, Ordering::Relaxed);
-            if main_thread {
-                search_stats.main_iters.fetch_add(1, Ordering::Relaxed);
-            }
+            search_stats.add_iter(thread_id, this_depth, main_thread);
 
             // proven checkmate
             if self.tree[self.tree.root_node()].is_terminal() {
@@ -153,9 +145,9 @@ impl<'a> Searcher<'a> {
         previous_score: &mut f32,
         #[cfg(not(feature = "uci-minimal"))] uci_output: bool,
     ) -> bool {
-        let iters = search_stats.main_iters.load(Ordering::Relaxed);
+        let iters = search_stats.main_iters();
 
-        if search_stats.total_iters.load(Ordering::Relaxed) >= limits.max_nodes {
+        if search_stats.total_iters() >= limits.max_nodes {
             return true;
         }
 
@@ -201,9 +193,8 @@ impl<'a> Searcher<'a> {
         }
 
         // define "depth" as the average depth of selection
-        let total_depth = search_stats.total_nodes.load(Ordering::Relaxed)
-            - search_stats.total_iters.load(Ordering::Relaxed);
-        let new_depth = total_depth / search_stats.total_iters.load(Ordering::Relaxed);
+        let total_depth = search_stats.total_nodes() - search_stats.total_iters();
+        let new_depth = total_depth / search_stats.total_iters();
         if new_depth > search_stats.avg_depth.load(Ordering::Relaxed) {
             search_stats.avg_depth.store(new_depth, Ordering::Relaxed);
             if new_depth >= limits.max_depth {
@@ -214,10 +205,10 @@ impl<'a> Searcher<'a> {
             if uci_output {
                 self.search_report(
                     new_depth,
-                    search_stats.seldepth.load(Ordering::Relaxed),
+                    search_stats.seldepth(),
                     timer,
-                    search_stats.total_nodes.load(Ordering::Relaxed),
-                    search_stats.total_iters.load(Ordering::Relaxed),
+                    search_stats.total_nodes(),
+                    search_stats.total_iters(),
                 );
 
                 *timer_last_output = Instant::now();
@@ -228,10 +219,10 @@ impl<'a> Searcher<'a> {
         if uci_output && iters % 8192 == 0 && timer_last_output.elapsed().as_secs() >= 15 {
             self.search_report(
                 search_stats.avg_depth.load(Ordering::Relaxed),
-                search_stats.seldepth.load(Ordering::Relaxed),
+                search_stats.seldepth(),
                 timer,
-                search_stats.total_nodes.load(Ordering::Relaxed),
-                search_stats.total_iters.load(Ordering::Relaxed),
+                search_stats.total_nodes(),
+                search_stats.total_iters(),
             );
 
             *timer_last_output = Instant::now();
@@ -262,7 +253,7 @@ impl<'a> Searcher<'a> {
             assert_eq!(node, ptr);
 
             self.tree[ptr].clear();
-            self.tree.expand_node(ptr, pos, self.params, self.policy, 1);
+            self.tree.expand_node(ptr, pos, self.params, self.policy, 1, 0);
 
             let root_eval = pos.get_value_wdl(self.value, self.params);
             self.tree[ptr].update(1.0 - root_eval);
@@ -288,7 +279,7 @@ impl<'a> Searcher<'a> {
             }
         }
 
-        let search_stats = SearchStats::default();
+        let search_stats = std::sync::Arc::new(SearchStats::new(threads));
 
         let mut best_move = Move::NULL;
         let mut best_move_changes = 0;
@@ -296,24 +287,28 @@ impl<'a> Searcher<'a> {
 
         // search loop
         while !self.abort.load(Ordering::Relaxed) {
+            let stats_ref = search_stats.clone();
             thread::scope(|s| {
-                s.spawn(|| {
+                let stats_ref_main = stats_ref.clone();
+                s.spawn(move || {
                     self.playout_until_full_main(
                         &limits,
                         &timer,
                         #[cfg(not(feature = "uci-minimal"))]
                         &mut timer_last_output,
-                        &search_stats,
+                        &stats_ref_main,
                         &mut best_move,
                         &mut best_move_changes,
                         &mut previous_score,
                         #[cfg(not(feature = "uci-minimal"))]
                         uci_output,
+                        0,
                     );
                 });
 
-                for _ in 0..threads - 1 {
-                    s.spawn(|| self.playout_until_full_worker(&search_stats));
+                for i in 1..threads {
+                    let stats_ref_worker = stats_ref.clone();
+                    s.spawn(move || self.playout_until_full_worker(&stats_ref_worker, i));
                 }
             });
 
@@ -322,15 +317,15 @@ impl<'a> Searcher<'a> {
             }
         }
 
-        *update_nodes += search_stats.total_nodes.load(Ordering::Relaxed);
+        *update_nodes += search_stats.total_nodes();
 
         if uci_output {
             self.search_report(
                 search_stats.avg_depth.load(Ordering::Relaxed).max(1),
-                search_stats.seldepth.load(Ordering::Relaxed),
+                search_stats.seldepth(),
                 &timer,
-                search_stats.total_nodes.load(Ordering::Relaxed),
-                search_stats.total_iters.load(Ordering::Relaxed),
+                search_stats.total_nodes(),
+                search_stats.total_iters(),
             );
         }
 

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -36,7 +36,14 @@ pub fn perform_one(
     } else {
         // expand node on the second visit
         if node.is_not_expanded() {
-            tree.expand_node(ptr, pos, searcher.params, searcher.policy, *depth, thread_id)?;
+            tree.expand_node(
+                ptr,
+                pos,
+                searcher.params,
+                searcher.policy,
+                *depth,
+                thread_id,
+            )?;
         }
 
         // this node has now been accessed so we need to move its

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -10,6 +10,7 @@ pub fn perform_one(
     pos: &mut ChessState,
     ptr: NodePtr,
     depth: &mut usize,
+    thread_id: usize,
 ) -> Option<f32> {
     *depth += 1;
 
@@ -35,12 +36,12 @@ pub fn perform_one(
     } else {
         // expand node on the second visit
         if node.is_not_expanded() {
-            tree.expand_node(ptr, pos, searcher.params, searcher.policy, *depth)?;
+            tree.expand_node(ptr, pos, searcher.params, searcher.policy, *depth, thread_id)?;
         }
 
         // this node has now been accessed so we need to move its
         // children across if they are in the other tree half
-        tree.fetch_children(ptr)?;
+        tree.fetch_children(ptr, thread_id)?;
 
         // select action to take via PUCT
         let action = pick_action(searcher, ptr, node);
@@ -62,7 +63,7 @@ pub fn perform_one(
         };
 
         // descend further
-        let maybe_u = perform_one(searcher, pos, child_ptr, depth);
+        let maybe_u = perform_one(searcher, pos, child_ptr, depth, thread_id);
 
         drop(lock);
 

--- a/src/mcts/search_stats.rs
+++ b/src/mcts/search_stats.rs
@@ -1,0 +1,70 @@
+use std::cell::UnsafeCell;
+use std::sync::atomic::AtomicUsize;
+
+#[derive(Default, Copy, Clone)]
+pub struct ThreadStats {
+    pub total_nodes: usize,
+    pub total_iters: usize,
+    pub main_iters: usize,
+    pub seldepth: usize,
+}
+
+pub struct SearchStats {
+    per_thread: Vec<UnsafeCell<ThreadStats>>, // accessed only by corresponding thread
+    pub avg_depth: AtomicUsize,
+}
+
+unsafe impl Sync for SearchStats {}
+
+impl SearchStats {
+    pub fn new(threads: usize) -> Self {
+        Self {
+            per_thread: (0..threads)
+                .map(|_| UnsafeCell::new(ThreadStats::default()))
+                .collect(),
+            avg_depth: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline]
+    pub fn add_iter(&self, tid: usize, depth: usize, main: bool) {
+        unsafe {
+            let stats = &mut *self.per_thread[tid].get();
+            stats.total_iters += 1;
+            stats.total_nodes += depth;
+            stats.seldepth = stats.seldepth.max(depth.saturating_sub(1));
+            if main {
+                stats.main_iters += 1;
+            }
+        }
+    }
+
+    pub fn total_iters(&self) -> usize {
+        self.per_thread
+            .iter()
+            .map(|c| unsafe { (*c.get()).total_iters })
+            .sum()
+    }
+
+    pub fn total_nodes(&self) -> usize {
+        self.per_thread
+            .iter()
+            .map(|c| unsafe { (*c.get()).total_nodes })
+            .sum()
+    }
+
+    pub fn main_iters(&self) -> usize {
+        self.per_thread
+            .iter()
+            .map(|c| unsafe { (*c.get()).main_iters })
+            .sum()
+    }
+
+    pub fn seldepth(&self) -> usize {
+        self.per_thread
+            .iter()
+            .map(|c| unsafe { (*c.get()).seldepth })
+            .max()
+            .unwrap_or(0)
+    }
+}

--- a/src/mcts/search_stats.rs
+++ b/src/mcts/search_stats.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[repr(align(64))]
 #[derive(Default)]
 pub struct ThreadStats {
     total_nodes: AtomicUsize,

--- a/src/tree/half.rs
+++ b/src/tree/half.rs
@@ -37,8 +37,7 @@ impl TreeHalf {
             use std::mem::MaybeUninit;
             let chunk_size = size.div_ceil(threads);
             let ptr = res.nodes.as_mut_ptr().cast();
-            let uninit: &mut [MaybeUninit<Node>] =
-                std::slice::from_raw_parts_mut(ptr, size);
+            let uninit: &mut [MaybeUninit<Node>] = std::slice::from_raw_parts_mut(ptr, size);
 
             std::thread::scope(|s| {
                 for chunk in uninit.chunks_mut(chunk_size) {

--- a/src/tree/half.rs
+++ b/src/tree/half.rs
@@ -84,12 +84,13 @@ impl TreeHalf {
     fn clear_ptrs_multi_threaded(&self, threads: usize) {
         std::thread::scope(|s| {
             let chunk_size = self.nodes.len().div_ceil(threads);
+            let half = self.half;
 
-            s.spawn(move || {
-                for node_chunk in self.nodes.chunks(chunk_size) {
-                    Self::clear_ptrs_single_threaded(self.half, node_chunk)
-                }
-            });
+            for chunk in self.nodes.chunks(chunk_size) {
+                s.spawn(move || {
+                    Self::clear_ptrs_single_threaded(half, chunk);
+                });
+            }
         });
     }
 


### PR DESCRIPTION
Changes:

- clear_ptrs_multi_threaded now spawns a worker per chunk, ensuring the pointer cleanup actually runs in parallel
- Search statistics were redesigned. Each thread records its own ThreadStats aligned to 64 bytes, with atomic counters for nodes, iterations, and depth tracking. Searcher threads pass a unique thread id and collect stats without shared atomics
- The tree allocator now serves memory from cached blocks. A global used pointer hands out blocks (CACHE_SIZE defaults to 1024) while per‑thread next/end cursors manage fast local allocations, avoiding contention and eliminating per‑thread exhaustion
- UCI options reinitialize the tree when thread count or hash size changes to keep the allocator consistent

These changes greatly reduce contention in multi-threaded search. Allocating nodes from per-thread memory blocks was the majority of the speed boost, while caching blocks for each thread prevents timeouts and crashes when threads exhaust their current chunk.

64 Thread performance (EPYC 9654 x2):

setoption name Threads value 64
setoption name Hash value 64000
go movetime 10000

Before:
info depth 12 seldepth 40 score cp 3 time 10023 nodes 42114039 nps 4201594 pv d2d4 g8f6 c2c4 e7e6 b1c3 f8b4 e2e3 e8g8 c1d2 b7b6 g1f3 c8b7

After:
info depth 14 seldepth 49 score cp 2 time 10002 nodes 192722505 nps 19268388 pv d2d4 g8f6 c2c4 e7e6 b1c3 f8b4 d1c2 e8g8 g1f3 d7d5 a2a3 b4c3 c2c3 b7b6

**Speedup: 4.59x**

Passed Non-Reg 1 Thread STC:
LLR: 2.97 (-2.94,2.94) <-3.50,0.50>
Total: 32160 W: 7994 L: 7922 D: 16244
Ptnml(0-2): 498, 3812, 7414, 3832, 524
https://tests.montychess.org/tests/view/68545a7bee7448c23622e587

Passed Gainer STC SMP:
LLR: 2.97 (-2.94,2.94) <1.00,5.00>
Total: 6792 W: 1987 L: 1785 D: 3020
Ptnml(0-2): 132, 727, 1497, 887, 153
https://tests.montychess.org/tests/view/68545addee7448c23622e58e

No functional change.
Bench: 1799102