### PR TITLE
Optimise policy evaluation

### DIFF
--- a/src/networks/accumulator.rs
+++ b/src/networks/accumulator.rs
@@ -58,6 +58,35 @@ impl<const N: usize> Accumulator<i16, N> {
 }
 
 impl<const N: usize> Accumulator<i16, N> {
+    pub fn add_multi_i8(&mut self, adds: &[usize], weights: &[Accumulator<i8, N>]) {
+        const REGS: usize = 8;
+        const PER: usize = REGS * 16;
+
+        let mut regs = [0i16; PER];
+
+        for i in 0..N / PER {
+            let offset = PER * i;
+
+            for (j, reg) in regs.iter_mut().enumerate() {
+                *reg = self.0[offset + j];
+            }
+
+            for &add in adds {
+                let this_weight = &weights[add];
+
+                for (j, reg) in regs.iter_mut().enumerate() {
+                    *reg += i16::from(this_weight.0[offset + j]);
+                }
+            }
+
+            for (j, reg) in regs.iter().enumerate() {
+                self.0[offset + j] = *reg;
+            }
+        }
+    }
+}
+
+impl<const N: usize> Accumulator<i16, N> {
     pub fn dot<T: Activation, const QA: i16>(&self, other: &Self) -> f32 {
         let mut res = 0.0;
 

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -35,11 +35,14 @@ impl PolicyNetwork {
             *r = i16::from(b);
         }
 
+        let mut feats = [0usize; 256];
+        let mut count = 0;
         pos.map_features(|feat| {
-            for (r, &w) in l1.0.iter_mut().zip(self.l1.weights[feat].0.iter()) {
-                *r += i16::from(w);
-            }
+            feats[count] = feat;
+            count += 1;
         });
+
+        l1.add_multi_i8(&feats[..count], &self.l1.weights);
 
         let mut res = Accumulator([0; L1 / 2]);
 


### PR DESCRIPTION
Adds Accumulator::add_multi_i8 - batch-adds multiple i8 weight vectors into an i16 accumulator in 128-element chunks, letting the compiler autovectorise.

Passed STC:
LLR: 2.92 (-2.94,2.94) <0.00,4.00>
Total: 6496 W: 1780 L: 1600 D: 3116
Ptnml(0-2): 92, 748, 1425, 854, 129
https://tests.montychess.org/tests/view/6859786aee7448c23622e636

No functional change.
Bench: 1799102