### PR TITLE
Reduce virtual loss contention

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -109,6 +109,7 @@ impl<'a> Searcher<'a> {
                 self.tree.root_node(),
                 &mut this_depth,
                 thread_id,
+                search_stats.threads(),
             )
             .is_none()
             {

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -11,6 +11,7 @@ pub fn perform_one(
     ptr: NodePtr,
     depth: &mut usize,
     thread_id: usize,
+    threads: usize,
 ) -> Option<f32> {
     *depth += 1;
 
@@ -51,7 +52,7 @@ pub fn perform_one(
         tree.fetch_children(ptr, thread_id)?;
 
         // select action to take via PUCT
-        let action = pick_action(searcher, ptr, node);
+        let action = pick_action(searcher, ptr, node, threads);
 
         let child_ptr = node.actions() + action;
 
@@ -59,7 +60,10 @@ pub fn perform_one(
 
         pos.make_move(mov);
 
-        tree[child_ptr].inc_threads();
+        let disable_vl = tree[child_ptr].visits() as usize > 1000 * threads;
+        if !disable_vl {
+            tree[child_ptr].inc_threads();
+        }
 
         // acquire lock to avoid issues with desynced setting of
         // game state between threads when threads > 1
@@ -70,11 +74,13 @@ pub fn perform_one(
         };
 
         // descend further
-        let maybe_u = perform_one(searcher, pos, child_ptr, depth, thread_id);
+        let maybe_u = perform_one(searcher, pos, child_ptr, depth, thread_id, threads);
 
         drop(lock);
 
-        tree[child_ptr].dec_threads();
+        if !disable_vl {
+            tree[child_ptr].dec_threads();
+        }
 
         let u = maybe_u?;
 
@@ -103,7 +109,7 @@ fn get_utility(searcher: &Searcher, ptr: NodePtr, pos: &ChessState) -> f32 {
     }
 }
 
-fn pick_action(searcher: &Searcher, ptr: NodePtr, node: &Node) -> usize {
+fn pick_action(searcher: &Searcher, ptr: NodePtr, node: &Node, threads: usize) -> usize {
     let is_root = ptr == searcher.tree.root_node();
 
     let cpuct = SearchHelpers::get_cpuct(searcher.params, node, is_root);
@@ -116,12 +122,14 @@ fn pick_action(searcher: &Searcher, ptr: NodePtr, node: &Node) -> usize {
         let mut q = SearchHelpers::get_action_value(child, fpu);
 
         // virtual loss
-        let threads = f64::from(child.threads());
-        if threads > 0.0 {
-            let visits = f64::from(child.visits());
-            let q2 = f64::from(q) * visits
-                / (visits + 1.0 + searcher.params.virtual_loss_weight() * (threads - 1.0));
-            q = q2 as f32;
+        if child.visits() as usize <= 1000 * threads {
+            let t = f64::from(child.threads());
+            if t > 0.0 {
+                let visits = f64::from(child.visits());
+                let q2 = f64::from(q) * visits
+                    / (visits + 1.0 + searcher.params.virtual_loss_weight() * (t - 1.0));
+                q = q2 as f32;
+            }
         }
 
         let u = expl * child.policy() / (1 + child.visits()) as f32;

--- a/src/mcts/search_stats.rs
+++ b/src/mcts/search_stats.rs
@@ -22,6 +22,10 @@ impl SearchStats {
         }
     }
 
+    pub fn threads(&self) -> usize {
+        self.per_thread.len()
+    }
+
     #[inline]
     pub fn add_iter(&self, tid: usize, depth: usize, main: bool) {
         let stats = &self.per_thread[tid];


### PR DESCRIPTION
When visits exceed threads * 1000, turn off virtual loss completely.

Passed STC SMP:
LLR: 2.93 (-2.94,2.94) <0.00,4.00>
Total: 13208 W: 3256 L: 3068 D: 6884
Ptnml(0-2): 120, 1545, 3103, 1699, 137
https://tests.montychess.org/tests/view/6870918c48629dc8d8a9fc70

48 Thread performance (EPYC 9654 x2):

setoption name Threads value 48
setoption name Hash value 48000
go movetime 10000

master:
info depth 14 seldepth 45 score cp 3 time 10004 nodes 217191296 nps 21709748 pv d2d4 g8f6 c2c4 e7e6 g2g3 f8e7 f1g2 d7d5 g1f3 e8g8 e1g1 d5c4 f3e5 b8c6

patch:
info depth 14 seldepth 44 score cp 2 time 10003 nodes 252150679 nps 25207168 pv d2d4 g8f6 c2c4 e7e6 g2g3 a7a6 f1g2 d7d5 g1f3 d5c4 e1g1 b8c6 e2e3 c8d7

**Speedup: 16.1%**

No functional change.
Bench: 1799102