### PR TITLE
Introduce Correction History

### DIFF
--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -2,9 +2,9 @@ use crate::{Destination, Rand};
 
 use monty::{
     chess::{ChessState, GameState},
+    correction_history::CorrectionHistory,
     mcts::{Limits, MctsParams, Searcher},
     networks::{PolicyNetwork, ValueNetwork},
-    correction_history::CorrectionHistory,
     tree::Tree,
 };
 use montyformat::{MontyFormat, MontyValueFormat, SearchData};

--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -4,6 +4,7 @@ use monty::{
     chess::{ChessState, GameState},
     mcts::{Limits, MctsParams, Searcher},
     networks::{PolicyNetwork, ValueNetwork},
+    correction_history::CorrectionHistory,
     tree::Tree,
 };
 use montyformat::{MontyFormat, MontyValueFormat, SearchData};
@@ -98,6 +99,7 @@ impl<'a> DatagenThread<'a> {
         let mut result = 0.5;
 
         let mut tree = Tree::new_mb(8, 1);
+        let corr = CorrectionHistory::new();
 
         let pos = position.board();
 
@@ -132,7 +134,7 @@ impl<'a> DatagenThread<'a> {
 
             let abort = AtomicBool::new(false);
             tree.set_root_position(&position);
-            let searcher = Searcher::new(&tree, &self.params, policy, value, &abort);
+            let searcher = Searcher::new(&tree, &self.params, policy, value, &corr, &abort);
 
             let (bm, score) = searcher.search(1, limits, false, &mut 0);
 

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -149,11 +149,7 @@ impl ChessState {
         self.board.piece(piece).count_ones() as i32
     }
 
-    pub fn get_value(
-        &self,
-        value: &ValueNetwork,
-        _params: &MctsParams,
-    ) -> i32 {
+    pub fn get_value(&self, value: &ValueNetwork, _params: &MctsParams) -> i32 {
         const K: f32 = 400.0;
         let (win, draw, _) = value.eval(&self.board);
 

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -149,7 +149,11 @@ impl ChessState {
         self.board.piece(piece).count_ones() as i32
     }
 
-    pub fn get_value(&self, value: &ValueNetwork, _params: &MctsParams) -> i32 {
+    pub fn get_value(
+        &self,
+        value: &ValueNetwork,
+        _params: &MctsParams,
+    ) -> i32 {
         const K: f32 = 400.0;
         let (win, draw, _) = value.eval(&self.board);
 
@@ -174,8 +178,27 @@ impl ChessState {
         cp
     }
 
+    pub fn get_value_corr(
+        &self,
+        value: &ValueNetwork,
+        params: &MctsParams,
+        corr: &crate::correction_history::CorrectionHistory,
+    ) -> i32 {
+        let base = self.get_value(value, params);
+        corr.apply(&self.board, base)
+    }
+
     pub fn get_value_wdl(&self, value: &ValueNetwork, params: &MctsParams) -> f32 {
         1.0 / (1.0 + (-(self.get_value(value, params) as f32) / 400.0).exp())
+    }
+
+    pub fn get_value_wdl_corr(
+        &self,
+        value: &ValueNetwork,
+        params: &MctsParams,
+        corr: &crate::correction_history::CorrectionHistory,
+    ) -> f32 {
+        1.0 / (1.0 + (-(self.get_value_corr(value, params, corr) as f32) / 400.0).exp())
     }
 
     pub fn perft(&self, depth: usize) -> u64 {

--- a/src/correction_history.rs
+++ b/src/correction_history.rs
@@ -12,6 +12,12 @@ pub struct CorrectionHistory {
     table: Vec<AtomicI32>,
 }
 
+impl Default for CorrectionHistory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CorrectionHistory {
     /// Create a new correction history table
     pub fn new() -> Self {

--- a/src/correction_history.rs
+++ b/src/correction_history.rs
@@ -1,0 +1,49 @@
+use std::sync::atomic::{AtomicI32, Ordering};
+
+use crate::chess::Board;
+
+/// Parameters for correction history.
+const CORRHIST_SIZE: usize = 1 << 18; // 256k entries
+const CORRHIST_GRAIN: i32 = 8; // scaling factor
+const CORRHIST_WEIGHT_SCALE: i32 = 128;
+const CORRHIST_MAX: i32 = 4000; // roughly 4000 centipawns
+
+pub struct CorrectionHistory {
+    table: Vec<AtomicI32>,
+}
+
+impl CorrectionHistory {
+    /// Create a new correction history table
+    pub fn new() -> Self {
+        Self {
+            table: (0..CORRHIST_SIZE).map(|_| AtomicI32::new(0)).collect(),
+        }
+    }
+
+    #[inline]
+    fn index(&self, board: &Board) -> usize {
+        board.hash() as usize % CORRHIST_SIZE
+    }
+
+    /// Return the current correction in centipawns for the board
+    pub fn get(&self, board: &Board) -> i32 {
+        self.table[self.index(board)].load(Ordering::Relaxed) / CORRHIST_GRAIN
+    }
+
+    /// Adjust a static evaluation with correction history
+    pub fn apply(&self, board: &Board, eval: i32) -> i32 {
+        eval + self.get(board)
+    }
+
+    /// Update correction history using depth and evaluation difference
+    pub fn update(&self, board: &Board, depth: usize, diff: i32) {
+        let idx = self.index(board);
+        let entry = self.table[idx].load(Ordering::Relaxed);
+        let scaled_diff = diff.saturating_mul(CORRHIST_GRAIN);
+        let new_weight = ((depth * depth + 2 * depth + 1) as i32).min(CORRHIST_WEIGHT_SCALE);
+        let value = (entry * (CORRHIST_WEIGHT_SCALE - new_weight) + scaled_diff * new_weight)
+            / CORRHIST_WEIGHT_SCALE;
+        let clamped = value.clamp(-CORRHIST_MAX, CORRHIST_MAX);
+        self.table[idx].store(clamped, Ordering::Relaxed);
+    }
+}

--- a/src/correction_history.rs
+++ b/src/correction_history.rs
@@ -4,7 +4,7 @@ use crate::chess::Board;
 
 /// Parameters for correction history.
 const CORRHIST_SIZE: usize = 1 << 16; // 64k entries
-const CORRHIST_WEIGHT_SCALE: i32 = 4;
+const CORRHIST_WEIGHT_SCALE: i32 = 64;
 
 pub struct CorrectionHistory {
     table: Vec<AtomicI32>,

--- a/src/correction_history.rs
+++ b/src/correction_history.rs
@@ -3,8 +3,8 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use crate::chess::Board;
 
 /// Parameters for correction history.
-const CORRHIST_SIZE: usize = 1 << 18; // 256k entries
-const CORRHIST_WEIGHT_SCALE: i32 = 16;
+const CORRHIST_SIZE: usize = 1 << 16; // 64k entries
+const CORRHIST_WEIGHT_SCALE: i32 = 4;
 
 pub struct CorrectionHistory {
     table: Vec<AtomicI32>,

--- a/src/correction_history.rs
+++ b/src/correction_history.rs
@@ -5,7 +5,6 @@ use crate::chess::Board;
 /// Parameters for correction history.
 const CORRHIST_SIZE: usize = 1 << 18; // 256k entries
 const CORRHIST_WEIGHT_SCALE: i32 = 16;
-const CORRHIST_MAX: i32 = 3200;
 
 pub struct CorrectionHistory {
     table: Vec<AtomicI32>,
@@ -44,9 +43,7 @@ impl CorrectionHistory {
     pub fn update(&self, board: &Board, diff: i32) {
         let idx = self.index(board);
         let entry = self.table[idx].load(Ordering::Relaxed);
-        let value = (entry * (CORRHIST_WEIGHT_SCALE - 1) + diff)
-            / CORRHIST_WEIGHT_SCALE;
-        let clamped = value.clamp(-CORRHIST_MAX, CORRHIST_MAX);
-        self.table[idx].store(clamped, Ordering::Relaxed);
+        let value = (entry * (CORRHIST_WEIGHT_SCALE - 1) + diff) / CORRHIST_WEIGHT_SCALE;
+        self.table[idx].store(value, Ordering::Relaxed);
     }
 }

--- a/src/correction_history.rs
+++ b/src/correction_history.rs
@@ -4,7 +4,6 @@ use crate::chess::Board;
 
 /// Parameters for correction history.
 const CORRHIST_SIZE: usize = 1 << 18; // 256k entries
-const CORRHIST_GRAIN: i32 = 16; // scaling factor
 const CORRHIST_WEIGHT_SCALE: i32 = 16;
 const CORRHIST_MAX: i32 = 3200;
 
@@ -33,7 +32,7 @@ impl CorrectionHistory {
 
     /// Return the current correction in centipawns for the board
     pub fn get(&self, board: &Board) -> i32 {
-        self.table[self.index(board)].load(Ordering::Relaxed) / CORRHIST_GRAIN
+        self.table[self.index(board)].load(Ordering::Relaxed)
     }
 
     /// Adjust a static evaluation with correction history
@@ -45,7 +44,7 @@ impl CorrectionHistory {
     pub fn update(&self, board: &Board, diff: i32) {
         let idx = self.index(board);
         let entry = self.table[idx].load(Ordering::Relaxed);
-        let value = (entry * (CORRHIST_WEIGHT_SCALE - 1) + diff * CORRHIST_GRAIN)
+        let value = (entry * (CORRHIST_WEIGHT_SCALE - 1) + diff)
             / CORRHIST_WEIGHT_SCALE;
         let clamped = value.clamp(-CORRHIST_MAX, CORRHIST_MAX);
         self.table[idx].store(clamped, Ordering::Relaxed);

--- a/src/correction_history.rs
+++ b/src/correction_history.rs
@@ -3,10 +3,10 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use crate::chess::Board;
 
 /// Parameters for correction history.
-const CORRHIST_SIZE: usize = 1 << 18; // 256k entries
-const CORRHIST_GRAIN: i32 = 8; // scaling factor
-const CORRHIST_WEIGHT_SCALE: i32 = 128;
-const CORRHIST_MAX: i32 = 4000; // roughly 4000 centipawns
+const CORRHIST_SIZE: usize = 1 << 20; // 1024k entries
+const CORRHIST_GRAIN: i32 = 16; // scaling factor
+const CORRHIST_WEIGHT_SCALE: i32 = 256;
+const CORRHIST_MAX: i32 = 3200;
 
 pub struct CorrectionHistory {
     table: Vec<AtomicI32>,
@@ -46,7 +46,7 @@ impl CorrectionHistory {
         let idx = self.index(board);
         let entry = self.table[idx].load(Ordering::Relaxed);
         let scaled_diff = diff.saturating_mul(CORRHIST_GRAIN);
-        let new_weight = ((depth * depth + 2 * depth + 1) as i32).min(CORRHIST_WEIGHT_SCALE);
+        let new_weight = ((depth * depth) as i32).min(CORRHIST_WEIGHT_SCALE);
         let value = (entry * (CORRHIST_WEIGHT_SCALE - new_weight) + scaled_diff * new_weight)
             / CORRHIST_WEIGHT_SCALE;
         let clamped = value.clamp(-CORRHIST_MAX, CORRHIST_MAX);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod chess;
+pub mod correction_history;
 pub mod mcts;
 pub mod networks;
 pub mod tree;
 pub mod uci;
-pub mod correction_history;
 
 use memmap2::Mmap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod mcts;
 pub mod networks;
 pub mod tree;
 pub mod uci;
+pub mod correction_history;
 
 use memmap2::Mmap;
 

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -337,7 +337,6 @@ impl<'a> Searcher<'a> {
         let (_, mov, q) = self.get_best_action(self.tree.root_node());
 
         let final_cp = Searcher::get_cp(q);
-        let depth = search_stats.seldepth();
         self.corr
             .update(&pos.board(), final_cp as i32 - static_cp as i32);
 

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -339,7 +339,7 @@ impl<'a> Searcher<'a> {
         let final_cp = Searcher::get_cp(q);
         let depth = search_stats.seldepth();
         self.corr
-            .update(&pos.board(), depth, final_cp as i32 - static_cp as i32);
+            .update(&pos.board(), final_cp as i32 - static_cp as i32);
 
         (mov, q)
     }

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -338,7 +338,8 @@ impl<'a> Searcher<'a> {
 
         let final_cp = Searcher::get_cp(q);
         let depth = search_stats.seldepth();
-        self.corr.update(&pos.board(), depth, final_cp as i32 - static_cp as i32);
+        self.corr
+            .update(&pos.board(), depth, final_cp as i32 - static_cp as i32);
 
         (mov, q)
     }

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -96,7 +96,11 @@ pub fn perform_one(
 
 fn get_utility(searcher: &Searcher, ptr: NodePtr, pos: &ChessState) -> f32 {
     match searcher.tree[ptr].state() {
-        GameState::Ongoing => pos.get_value_wdl(searcher.value, searcher.params),
+        GameState::Ongoing => pos.get_value_wdl_corr(
+            searcher.value,
+            searcher.params,
+            searcher.corr,
+        ),
         GameState::Draw => 0.5,
         GameState::Lost(_) => 0.0,
         GameState::Won(_) => 1.0,

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -96,11 +96,9 @@ pub fn perform_one(
 
 fn get_utility(searcher: &Searcher, ptr: NodePtr, pos: &ChessState) -> f32 {
     match searcher.tree[ptr].state() {
-        GameState::Ongoing => pos.get_value_wdl_corr(
-            searcher.value,
-            searcher.params,
-            searcher.corr,
-        ),
+        GameState::Ongoing => {
+            pos.get_value_wdl_corr(searcher.value, searcher.params, searcher.corr)
+        }
         GameState::Draw => 0.5,
         GameState::Lost(_) => 0.0,
         GameState::Won(_) => 1.0,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,9 +1,9 @@
 use crate::{
     chess::{ChessState, Move},
+    correction_history::CorrectionHistory,
     mcts::{Limits, MctsParams, SearchHelpers, Searcher, REPORT_ITERS},
     networks::{PolicyNetwork, ValueNetwork},
     tree::Tree,
-    correction_history::CorrectionHistory,
 };
 
 use std::{
@@ -88,7 +88,10 @@ pub fn run(policy: &PolicyNetwork, value: &ValueNetwork) {
             "quit" => std::process::exit(0),
             "eval" => {
                 println!("cp: {}", pos.get_value_corr(value, &params, &corr));
-                println!("wdl: {:.2}%", 100.0 * pos.get_value_wdl_corr(value, &params, &corr));
+                println!(
+                    "wdl: {:.2}%",
+                    100.0 * pos.get_value_wdl_corr(value, &params, &corr)
+                );
             }
             "policy" => {
                 let mut max = f32::NEG_INFINITY;
@@ -404,7 +407,7 @@ fn go(
 
     std::thread::scope(|s| {
         s.spawn(|| {
-            let searcher = Searcher::new(tree, params, policy, value, &corr, &abort);
+            let searcher = Searcher::new(tree, params, policy, value, corr, &abort);
             let (mov, _) = searcher.search(threads, limits, true, &mut 0);
             println!("bestmove {}", pos.conv_mov_to_str(mov));
 


### PR DESCRIPTION
1k nodes result:
Results of Patch vs Baseline (1000 nodes, 1t, 64MB, UHO_Lichess_4852_v1.epd):
Elo: -38.90 +/- 4.79, nElo: -55.80 +/- 6.81
LOS: 0.00 %, DrawRatio: 39.00 %, PairsRatio: 0.58
Games: 10000, Wins: 2424, Losses: 3539, Draws: 4037, Points: 4442.5 (44.42 %)
Ptnml(0-2): [486, 1447, 1950, 930, 187], WL/DD Ratio: 1.35

STC:
https://tests.montychess.org/tests/view/68874135b8fc2ad7b53d4ff0

LTC:
https://tests.montychess.org/tests/view/688746e1b8fc2ad7b53d4ff6

(Results pending)

Bench: 1783755