### PR TITLE
Ensure U is always stored in TT from Side to Move Perspective 

### DIFF
--- a/src/networks/activation.rs
+++ b/src/networks/activation.rs
@@ -2,14 +2,6 @@ pub trait Activation {
     fn activate(x: f32) -> f32;
 }
 
-pub struct ReLU;
-impl Activation for ReLU {
-    #[inline]
-    fn activate(x: f32) -> f32 {
-        x.max(0.0)
-    }
-}
-
 pub struct SCReLU;
 impl Activation for SCReLU {
     #[inline]

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -142,7 +142,7 @@ impl Node {
         self.actions.read()
     }
 
-    pub fn actions_mut(&self) -> WriteGuard {
+    pub fn actions_mut(&self) -> WriteGuard<'_> {
         self.actions.write()
     }
 


### PR DESCRIPTION
Store TT values from the side-to-move’s perspective using the child hash when available. Fixes new clippy warnings also.

Passed STC:
LLR: 2.92 (-2.94,2.94) <0.00,4.00>
Total: 5056 W: 1345 L: 1171 D: 2540
Ptnml(0-2): 79, 538, 1130, 692, 89
https://tests.montychess.org/tests/view/6898f36e56f229dd4390d4af

Passed LTC:
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 4548 W: 1064 L: 906 D: 2578
Ptnml(0-2): 23, 467, 1153, 591, 40
https://tests.montychess.org/tests/view/6898f4b956f229dd4390d4b2

Bench: 1494093