### PR TITLE
Make value and policy datagen distinct Make targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ raw = []
 datagen = ["rand", "rand_distr"]
 uci-minimal = []
 tunable = []
+value = []
+policy = []
 
 [workspace]
 members = ["datagen"]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ noembed:
 	$(INVOKE) --bin monty $(LINK)
 
 gen-value:
-	$(INVOKE) --package datagen --bin datagen --features value
+	$(INVOKE) --package datagen --bin datagen --features value $(LINK)
 
 gen-policy:
-	$(INVOKE) --package datagen --bin datagen --features policy
+	$(INVOKE) --package datagen --bin datagen --features policy $(LINK)

--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,8 @@ montytest:
 noembed:
 	$(INVOKE) --bin monty $(LINK)
 
-gen:
-	$(INVOKE) --package datagen --bin datagen $(LINK)
+gen-value:
+	$(INVOKE) --package datagen --bin datagen --features value
+
+gen-policy:
+	$(INVOKE) --package datagen --bin datagen --features policy

--- a/datagen/Cargo.toml
+++ b/datagen/Cargo.toml
@@ -9,6 +9,6 @@ monty = { path = "../", features = ["datagen"] }
 montyformat = "0.9.1"
 
 [features]
-default = []
+default = ["monty/value"]
 value   = ["monty/value"]
 policy  = ["monty/policy"]

--- a/datagen/Cargo.toml
+++ b/datagen/Cargo.toml
@@ -7,3 +7,8 @@ authors = ["Jamie Whiting, Viren & The Monty Authors"]
 [dependencies]
 monty = { path = "../", features = ["datagen"] }
 montyformat = "0.9.1"
+
+[features]
+default = []
+value   = ["monty/value"]
+policy  = ["monty/policy"]

--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -191,7 +191,7 @@ impl<'a> DatagenThread<'a> {
         if output_policy {
             dest.push_policy(&policy_game, self.stop, searches, total_iters);
         } else {
-            dest.push(&value_game, self.stop);
+            dest.push(&value_game, self.stop, searches, total_iters);
         }
     }
 }

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -325,7 +325,16 @@ impl<'a> Searcher<'a> {
         // add dirichlet noise in datagen
         #[cfg(feature = "datagen")]
         if use_dirichlet_noise {
-            self.tree.add_dirichlet_noise_to_node(node, 0.03, 0.25);
+            let epsilon = 0.03;
+            let alpha = {
+                #[cfg(feature = "policy")]
+                { 0.05 }
+
+                #[cfg(feature = "value")]
+                { 0.25 }
+            };
+
+            self.tree.add_dirichlet_noise_to_node(node, epsilon, alpha);
         }
 
         let search_stats = SearchStats::new(threads);

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -328,10 +328,14 @@ impl<'a> Searcher<'a> {
             let epsilon = 0.03;
             let alpha = {
                 #[cfg(feature = "policy")]
-                { 0.05 }
+                {
+                    0.05
+                }
 
                 #[cfg(feature = "value")]
-                { 0.25 }
+                {
+                    0.25
+                }
             };
 
             self.tree.add_dirichlet_noise_to_node(node, epsilon, alpha);

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -14,7 +14,7 @@ pub const PolicyFileDefaultName: &str = "nn-06e27b5ef6e7.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedPolicyName: &str = "nn-bef5cb915ecf.network";
 #[allow(non_upper_case_globals, dead_code)]
-pub const DatagenPolicyFileName: &str = "nn-6764ee301f3e.network";
+pub const DatagenPolicyFileName: &str = "nn-06e27b5ef6e7.network";
 
 const QA: i16 = 128;
 const QB: i16 = 128;
@@ -24,7 +24,7 @@ const FACTOR: i16 = 32;
 pub const L1: usize = 16384;
 
 #[cfg(feature = "datagen")]
-pub const L1: usize = 6144;
+pub const L1: usize = 16384;
 
 #[repr(C)]
 #[derive(Clone, Copy)]


### PR DESCRIPTION
This enables selecting value or policy with 1 button click on Montytest side and using master directly (no branch even required for either)

No functional change.

Bench: 1458762