### PR TITLE
New Value Network: `nn-898b5f117c5a.network`

### DIFF
--- a/src/networks/threats.rs
+++ b/src/networks/threats.rs
@@ -10,7 +10,7 @@ pub fn map_features<F: FnMut(usize)>(pos: &Board, mut f: F) {
     let mut bbs = pos.bbs();
 
     // flip to stm perspective
-    if pos.stm() == Side::WHITE {
+    if pos.stm() == Side::BLACK {
         bbs.swap(0, 1);
         for bb in bbs.iter_mut() {
             *bb = bb.swap_bytes()
@@ -108,7 +108,7 @@ const fn offset_mapping<const N: usize>(a: [usize; N]) -> [usize; 12] {
     let mut i = 0;
     while i < N {
         res[a[i] - 2] = i;
-        res[a[i] + 4] = i;
+        res[a[i] + 4] = i + N;
         i += 1;
     }
 
@@ -124,10 +124,12 @@ fn map_pawn_threat(src: usize, dest: usize, target: usize, enemy: bool) -> Optio
     if MAP[target] == usize::MAX || (enemy && dest > src && target_is(target, Piece::PAWN)) {
         None
     } else {
+        let up = usize::from(dest > src);
         let diff = dest.abs_diff(src);
-        let attack = if diff == 7 { 0 } else { 1 } + 2 * (src % 8) - 1;
+        let id = if diff == [9, 7][up] { 0 } else { 1 };
+        let attack = 2 * (src % 8) + id - 1;
         let threat =
-            ValueOffsets::PAWN + MAP[target] * ValueIndices::PAWN + (src / 8) * 14 + attack;
+            ValueOffsets::PAWN + MAP[target] * ValueIndices::PAWN + (src / 8 - 1) * 14 + attack;
 
         assert!(threat < ValueOffsets::KNIGHT, "{threat}");
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -12,7 +12,7 @@ pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]
-pub const DatagenValueFileName: &str = "nn-898b5f117c5a.network";
+pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
 
 const QA: i16 = 512;
 const QB: i16 = 1024;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "sb800-fixed-threats.network";
+pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -12,7 +12,7 @@ pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]
-pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
+pub const DatagenValueFileName: &str = "nn-898b5f117c5a.network";
 
 const QA: i16 = 512;
 const QB: i16 = 1024;

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -10,7 +10,7 @@ use super::{
 #[allow(non_upper_case_globals, dead_code)]
 pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
 #[allow(non_upper_case_globals, dead_code)]
-pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
+pub const CompressedValueName: &str = "nn-898b5f117c5a.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "nn-5601bb8c241d.network";
+pub const ValueFileDefaultName: &str = "sb800-fixed-threats.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]
@@ -20,7 +20,7 @@ const FACTOR: i16 = 32;
 
 const L1: usize = 3072;
 
-#[repr(C)]
+#[repr(C, align(64))]
 pub struct ValueNetwork {
     pst: [Accumulator<f32, 3>; threats::TOTAL],
     l1: Layer<i16, { threats::TOTAL }, L1>,


### PR DESCRIPTION
Fixed Threat input indexing: Now threat inputs are correctly seperated by colour + A minor pawn indexing fix. Uses the first 10 binpacks from https://huggingface.co/datasets/Viren6/MontyValue7 : 500M games

This net can be recreated with 3 weeks of datagen on a 2x EPYC 9654 system and 3 days training on a 1x RTX 4090.

Passed STC:
Elo: 40.44 ± 1.8 (95%) LOS: 100.0%
Total: 60000 W: 20279 L: 13326 D: 26395
Ptnml(0-2): 724, 5416, 12305, 9293, 2262
nElo: 62.32 ± 2.8 (95%) PairsRatio: 1.88
https://tests.montychess.org/tests/view/68b23cfb56f229dd4390d6fd

Passed LTC:
Elo: 25.23 ± 2.7 (95%) LOS: 100.0%
Total: 20000 W: 5573 L: 4123 D: 10304
Ptnml(0-2): 94, 1966, 4665, 2946, 329
nElo: 44.55 ± 4.8 (95%) PairsRatio: 1.59
https://tests.montychess.org/tests/view/68b23d0656f229dd4390d6ff

Bench: 1429448