### PR TITLE
New Value Network: `nn-f39ae0a13058.network`

### DIFF
--- a/src/networks/threats.rs
+++ b/src/networks/threats.rs
@@ -10,7 +10,7 @@ pub fn map_features<F: FnMut(usize)>(pos: &Board, mut f: F) {
     let mut bbs = pos.bbs();
 
     // flip to stm perspective
-    if pos.stm() == Side::WHITE {
+    if pos.stm() == Side::BLACK {
         bbs.swap(0, 1);
         for bb in bbs.iter_mut() {
             *bb = bb.swap_bytes()
@@ -108,7 +108,7 @@ const fn offset_mapping<const N: usize>(a: [usize; N]) -> [usize; 12] {
     let mut i = 0;
     while i < N {
         res[a[i] - 2] = i;
-        res[a[i] + 4] = i;
+        res[a[i] + 4] = i + N;
         i += 1;
     }
 
@@ -124,10 +124,12 @@ fn map_pawn_threat(src: usize, dest: usize, target: usize, enemy: bool) -> Optio
     if MAP[target] == usize::MAX || (enemy && dest > src && target_is(target, Piece::PAWN)) {
         None
     } else {
+        let up = usize::from(dest > src);
         let diff = dest.abs_diff(src);
-        let attack = if diff == 7 { 0 } else { 1 } + 2 * (src % 8) - 1;
+        let id = if diff == [9, 7][up] { 0 } else { 1 };
+        let attack = 2 * (src % 8) + id - 1;
         let threat =
-            ValueOffsets::PAWN + MAP[target] * ValueIndices::PAWN + (src / 8) * 14 + attack;
+            ValueOffsets::PAWN + MAP[target] * ValueIndices::PAWN + (src / 8 - 1) * 14 + attack;
 
         assert!(threat < ValueOffsets::KNIGHT, "{threat}");
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -10,7 +10,7 @@ use super::{
 #[allow(non_upper_case_globals, dead_code)]
 pub const ValueFileDefaultName: &str = "nn-7bf8d51714b5.network";
 #[allow(non_upper_case_globals, dead_code)]
-pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
+pub const CompressedValueName: &str = "nn-f39ae0a13058.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "sb800-fixed-threats.network";
+pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
+pub const ValueFileDefaultName: &str = "nn-7bf8d51714b5.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "nn-5601bb8c241d.network";
+pub const ValueFileDefaultName: &str = "sb800-fixed-threats.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]
@@ -20,7 +20,7 @@ const FACTOR: i16 = 32;
 
 const L1: usize = 3072;
 
-#[repr(C)]
+#[repr(C, align(64))]
 pub struct ValueNetwork {
     pst: [Accumulator<f32, 3>; threats::TOTAL],
     l1: Layer<i16, { threats::TOTAL }, L1>,


### PR DESCRIPTION
Use rounding for the i16 quantisation.

Passed STC:
Elo: 5.86 ± 1.7 (95%) LOS: 100.0%
Total: 60000 W: 15135 L: 14123 D: 30742
Ptnml(0-2): 780, 6936, 13717, 7626, 941
nElo: 9.81 ± 2.8 (95%) PairsRatio: 1.11
https://tests.montychess.org/tests/view/68b4ffe356f229dd4390d73d

Passed LTC:
Elo: 3.65 ± 2.5 (95%) LOS: 99.8%
Total: 20000 W: 4344 L: 4134 D: 11522
Ptnml(0-2): 78, 2298, 5073, 2438, 113
nElo: 6.96 ± 4.8 (95%) PairsRatio: 1.07
https://tests.montychess.org/tests/view/68b4f7de56f229dd4390d738

Bench: 1420912