### PR TITLE
New Value Network: `nn-fa1a8afd872c.network`

### DIFF
--- a/src/networks/threats.rs
+++ b/src/networks/threats.rs
@@ -10,7 +10,7 @@ pub fn map_features<F: FnMut(usize)>(pos: &Board, mut f: F) {
     let mut bbs = pos.bbs();
 
     // flip to stm perspective
-    if pos.stm() == Side::WHITE {
+    if pos.stm() == Side::BLACK {
         bbs.swap(0, 1);
         for bb in bbs.iter_mut() {
             *bb = bb.swap_bytes()
@@ -108,7 +108,7 @@ const fn offset_mapping<const N: usize>(a: [usize; N]) -> [usize; 12] {
     let mut i = 0;
     while i < N {
         res[a[i] - 2] = i;
-        res[a[i] + 4] = i;
+        res[a[i] + 4] = i + N;
         i += 1;
     }
 
@@ -124,10 +124,12 @@ fn map_pawn_threat(src: usize, dest: usize, target: usize, enemy: bool) -> Optio
     if MAP[target] == usize::MAX || (enemy && dest > src && target_is(target, Piece::PAWN)) {
         None
     } else {
+        let up = usize::from(dest > src);
         let diff = dest.abs_diff(src);
-        let attack = if diff == 7 { 0 } else { 1 } + 2 * (src % 8) - 1;
+        let id = if diff == [9, 7][up] { 0 } else { 1 };
+        let attack = 2 * (src % 8) + id - 1;
         let threat =
-            ValueOffsets::PAWN + MAP[target] * ValueIndices::PAWN + (src / 8) * 14 + attack;
+            ValueOffsets::PAWN + MAP[target] * ValueIndices::PAWN + (src / 8 - 1) * 14 + attack;
 
         assert!(threat < ValueOffsets::KNIGHT, "{threat}");
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -10,7 +10,7 @@ use super::{
 #[allow(non_upper_case_globals, dead_code)]
 pub const ValueFileDefaultName: &str = "nn-58274aa39e13.network";
 #[allow(non_upper_case_globals, dead_code)]
-pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
+pub const CompressedValueName: &str = "nn-fa1a8afd872c.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "sb800-fixed-threats.network";
+pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "nn-04d9060cdbab.network";
+pub const ValueFileDefaultName: &str = "nn-7bf8d51714b5.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "nn-5601bb8c241d.network";
+pub const ValueFileDefaultName: &str = "sb800-fixed-threats.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]
@@ -20,7 +20,7 @@ const FACTOR: i16 = 32;
 
 const L1: usize = 3072;
 
-#[repr(C)]
+#[repr(C, align(64))]
 pub struct ValueNetwork {
     pst: [Accumulator<f32, 3>; threats::TOTAL],
     l1: Layer<i16, { threats::TOTAL }, L1>,

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,22 +8,21 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "nn-7bf8d51714b5.network";
+pub const ValueFileDefaultName: &str = "nn-58274aa39e13.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-f004da0ebf25.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
 
-const QA: i16 = 512;
+const QA: i16 = 128;
 const QB: i16 = 1024;
-const FACTOR: i16 = 32;
 
 const L1: usize = 3072;
 
 #[repr(C, align(64))]
 pub struct ValueNetwork {
     pst: [Accumulator<f32, 3>; threats::TOTAL],
-    l1: Layer<i16, { threats::TOTAL }, L1>,
+    l1: Layer<i8, { threats::TOTAL }, L1>,
     l2: TransposedLayer<i16, { L1 / 2 }, 16>,
     l3: Layer<f32, 16, 128>,
     l4: Layer<f32, 128, 3>,
@@ -41,9 +40,13 @@ impl ValueNetwork {
             count += 1;
         });
 
-        let mut l2 = self.l1.biases;
+        let mut l2 = Accumulator([0; L1]);
 
-        l2.add_multi(&feats[..count], &self.l1.weights);
+        for (r, &b) in l2.0.iter_mut().zip(self.l1.biases.0.iter()) {
+            *r = i16::from(b);
+        }
+
+        l2.add_multi_i8(&feats[..count], &self.l1.weights);
 
         let mut act = [0; L1 / 2];
 
@@ -51,9 +54,9 @@ impl ValueNetwork {
             .iter_mut()
             .zip(l2.0.iter().take(L1 / 2).zip(l2.0.iter().skip(L1 / 2)))
         {
-            let i = i32::from(i).clamp(0, i32::from(QA));
-            let j = i32::from(j).clamp(0, i32::from(QA));
-            *a = ((i * j) / i32::from(QA / FACTOR)) as i16;
+            let i = i.clamp(0, QA);
+            let j = j.clamp(0, QA);
+            *a = i * j;
         }
 
         let mut fwd = [0; 16];
@@ -67,7 +70,7 @@ impl ValueNetwork {
         let mut l3 = Accumulator([0.0; 16]);
 
         for (r, (&f, &b)) in l3.0.iter_mut().zip(fwd.iter().zip(self.l2.biases.0.iter())) {
-            *r = (f as f32 / f32::from(QA * FACTOR) + f32::from(b)) / f32::from(QB);
+            *r = (f as f32 / f32::from(QA * QA) + f32::from(b)) / f32::from(QB);
         }
 
         let l4 = self.l3.forward::<SCReLU>(&l3);


### PR DESCRIPTION
Quantise the input weights to i8.

Fixed nodes loss:
Results of Patch vs Baseline (1000 nodes, 1t, 64MB, UHO_Lichess_4852_v1.epd):
Elo: -5.22 +/- 3.16, nElo: -7.89 +/- 4.78
LOS: 0.06 %, DrawRatio: 41.16 %, PairsRatio: 0.93
Games: 20300, Wins: 5461, Losses: 5766, Draws: 9073, Points: 9997.5 (49.25 %)
Ptnml(0-2): [528, 2570, 4178, 2427, 447], WL/DD Ratio: 1.05

Passed STC:
LLR: 2.92 (-2.94,2.94) <0.00,4.00>
Total: 3424 W: 945 L: 783 D: 1696
Ptnml(0-2): 32, 366, 784, 468, 62
https://tests.montychess.org/tests/view/68b5d37756f229dd4390d7a1

Passed LTC:
LLR: 2.96 (-2.94,2.94) <1.00,5.00>
Total: 9606 W: 2132 L: 1956 D: 5518
Ptnml(0-2): 30, 1056, 2482, 1178, 57
https://tests.montychess.org/tests/view/68b5d72756f229dd4390d7a5

Passed STC SMP:
LLR: 2.92 (-2.94,2.94) <0.00,4.00>
Total: 4376 W: 1084 L: 933 D: 2359
Ptnml(0-2): 28, 442, 1106, 575, 37
https://tests.montychess.org/tests/view/68b5e53d56f229dd4390d7b1

Bench: 1436825