### PR TITLE
Introduce butterfly history

### DIFF
--- a/datagen/src/main.rs
+++ b/datagen/src/main.rs
@@ -50,7 +50,7 @@ pub fn to_slice_with_lifetime<T, U>(slice: &[T]) -> &[U] {
     let tgt_size = std::mem::size_of::<U>();
 
     assert!(
-        src_size % tgt_size == 0,
+        src_size.is_multiple_of(tgt_size),
         "Target type size does not divide slice size!"
     );
 
@@ -95,7 +95,7 @@ impl Destination {
             return;
         }
 
-        if self.games % 64 == 0 {
+        if self.games.is_multiple_of(64) {
             self.report();
         }
     }
@@ -128,7 +128,7 @@ impl Destination {
             return;
         }
 
-        if self.games % 64 == 0 {
+        if self.games.is_multiple_of(64) {
             self.report();
         }
     }

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -287,6 +287,8 @@ impl<'a> Searcher<'a> {
         let pos = self.tree.root_position();
         let node = self.tree.root_node();
 
+        self.tree.clear_butterfly_table();
+
         // the root node is added to an empty tree, **and not counted** towards the
         // total node count, in order for `go nodes 1` to give the expected result
         if self.tree.is_empty() {

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -287,8 +287,6 @@ impl<'a> Searcher<'a> {
         let pos = self.tree.root_position();
         let node = self.tree.root_node();
 
-        self.tree.clear_butterfly_table();
-
         // the root node is added to an empty tree, **and not counted** towards the
         // total node count, in order for `go nodes 1` to give the expected result
         if self.tree.is_empty() {

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -52,6 +52,7 @@ pub fn perform_one(
         tree.fetch_children(ptr, thread_id)?;
 
         // select action to take via PUCT
+        let stm = pos.stm();
         let action = pick_action(searcher, ptr, node);
 
         let child_ptr = node.actions() + action;
@@ -81,6 +82,10 @@ pub fn perform_one(
         tree[child_ptr].dec_threads();
 
         let u = maybe_u?;
+
+        if tree[child_ptr].state() == GameState::Ongoing {
+            tree.update_butterfly(stm, mov, u);
+        }
 
         tree.propogate_proven_mates(ptr, tree[child_ptr].state());
 

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -84,7 +84,7 @@ pub fn perform_one(
         let u = maybe_u?;
 
         if tree[child_ptr].state() == GameState::Ongoing {
-            tree.update_butterfly(stm, mov, u);
+            tree.update_butterfly(stm, mov, u, searcher.params);
         }
 
         tree.propogate_proven_mates(ptr, tree[child_ptr].state());

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -180,6 +180,8 @@ make_mcts_params! {
     tm_bmv4: f32 = 2.561, 0.1, 8.0, 0.4, 0.002;
     tm_bmv5: f32 = 0.634, 0.1, 1.0, 0.055, 0.002;
     tm_bmv6: f32 = 1.894, 0.1, 3.0, 0.15, 0.002;
+    butterfly_reduction_factor: i32 = 8192, 1, 65536, 819, 0.002;
+    butterfly_policy_divisor: i32 = 16384, 1, 131072, 1638, 0.002;
     policy_top_p: f32 = 0.7, 0.1, 1.0, 0.05, 0.002;
     min_policy_actions: i32 = 6, 1, 32, 1, 0.002;
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -10,7 +10,7 @@ pub use node::{Node, NodePtr};
 use std::{
     mem::MaybeUninit,
     ops::Index,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicI16, Ordering},
 };
 
 use crate::{
@@ -19,11 +19,74 @@ use crate::{
     networks::PolicyNetwork,
 };
 
+const NUM_SIDES: usize = 2;
+const NUM_SQUARES: usize = 64;
+
+struct ButterflyTable {
+    data: Vec<AtomicI16>,
+}
+
+impl ButterflyTable {
+    fn new() -> Self {
+        let capacity = NUM_SIDES * NUM_SQUARES * NUM_SQUARES;
+        let mut data = Vec::with_capacity(capacity);
+        data.extend((0..capacity).map(|_| AtomicI16::new(0)));
+        Self { data }
+    }
+
+    fn index(side: usize, from: u16, to: u16) -> usize {
+        side * NUM_SQUARES * NUM_SQUARES + usize::from(from) * NUM_SQUARES + usize::from(to)
+    }
+
+    fn entry(&self, side: usize, mov: Move) -> &AtomicI16 {
+        let idx = Self::index(side, mov.src(), mov.to());
+        &self.data[idx]
+    }
+
+    fn policy_bonus(&self, side: usize, mov: Move) -> f32 {
+        f32::from(self.entry(side, mov).load(Ordering::Relaxed)) / 16384.0
+    }
+
+    fn clear(&self) {
+        for entry in &self.data {
+            entry.store(0, Ordering::Relaxed);
+        }
+    }
+
+    fn update(&self, side: usize, mov: Move, score: f32) {
+        if !score.is_finite() {
+            return;
+        }
+
+        let score = score.clamp(0.001, 0.999);
+        let cp = (-400.0 * ((1.0 / score) - 1.0).ln()).round() as i32;
+        let cell = self.entry(side, mov);
+
+        let mut current = cell.load(Ordering::Relaxed);
+        loop {
+            let delta = scale_bonus(current, cp);
+            let new = current.saturating_add(delta);
+            match cell.compare_exchange(current, new, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+fn scale_bonus(score: i16, bonus: i32) -> i16 {
+    let bonus = bonus.clamp(i16::MIN as i32, i16::MAX as i32);
+    let reduction = i32::from(score) * bonus.abs() / 8192;
+    let adjusted = bonus - reduction;
+    adjusted.clamp(i16::MIN as i32, i16::MAX as i32) as i16
+}
+
 pub struct Tree {
     root: ChessState,
     tree: [TreeHalf; 2],
     half: AtomicBool,
     hash: HashTable,
+    butterfly: ButterflyTable,
 }
 
 impl Index<NodePtr> for Tree {
@@ -55,6 +118,7 @@ impl Tree {
             ],
             half: AtomicBool::new(false),
             hash: HashTable::new(hash_cap / 4, threads),
+            butterfly: ButterflyTable::new(),
         }
     }
 
@@ -153,6 +217,7 @@ impl Tree {
         self.root = ChessState::default();
         self.clear_halves();
         self.hash.clear(threads);
+        self.butterfly.clear();
     }
 
     pub fn is_empty(&self) -> bool {
@@ -182,11 +247,13 @@ impl Tree {
         let mut max = f32::NEG_INFINITY;
         let mut moves = [const { MaybeUninit::uninit() }; 256];
         let mut count = 0;
+        let stm = pos.stm();
 
         pos.map_moves_with_policies(policy, |mov, policy| {
-            moves[count].write((mov, policy));
+            let adjusted = policy + self.butterfly.policy_bonus(stm, mov);
+            moves[count].write((mov, adjusted));
             count += 1;
-            max = max.max(policy);
+            max = max.max(adjusted);
         });
 
         let new_ptr = self.tree[self.half()].reserve_nodes_thread(count, thread_id)?;
@@ -240,9 +307,10 @@ impl Tree {
         let mut max = f32::NEG_INFINITY;
         let mut policies = Vec::new();
 
+        let stm = pos.stm();
         for action in 0..num_actions {
             let mov = self[actions_ptr + action].parent_move();
-            let policy = pos.get_policy(mov, &hl, policy);
+            let policy = pos.get_policy(mov, &hl, policy) + self.butterfly.policy_bonus(stm, mov);
 
             policies.push(policy);
             max = max.max(policy);
@@ -267,6 +335,14 @@ impl Tree {
 
         let gini_impurity = (1.0 - sum_of_squares).clamp(0.0, 1.0);
         self[node_ptr].set_gini_impurity(gini_impurity);
+    }
+
+    pub fn update_butterfly(&self, side: usize, mov: Move, score: f32) {
+        self.butterfly.update(side, mov, score);
+    }
+
+    pub fn clear_butterfly_table(&self) {
+        self.butterfly.clear();
     }
 
     pub fn propogate_proven_mates(&self, ptr: NodePtr, child_state: GameState) {


### PR DESCRIPTION
Thanks to @aronpetko for this idea. Added a butterfly move-history table that biases policy logits using centipawn bonuses updated from search outcomes to steer future expansions. Uses per side from to indexing. Only gains when persisting the history across searches.  Also fixes new clippy warnings.

Passed STC:
LLR: 2.94 (-2.94,2.94) <0.00,4.00>
Total: 9824 W: 2438 L: 2256 D: 5130
Ptnml(0-2): 116, 1090, 2344, 1220, 142
https://tests.montychess.org/tests/view/68cacc6256f229dd4390ed21

Passed LTC:
LLR: 2.94 (-2.94,2.94) <1.00,5.00>
Total: 9378 W: 2074 L: 1900 D: 5404
Ptnml(0-2): 29, 1025, 2435, 1143, 57
https://tests.montychess.org/tests/view/68cad0a456f229dd4390ed25

Bench: 1159829