### PR TITLE
Introduce batching on root node

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -299,7 +299,7 @@ impl<'a> Searcher<'a> {
                 .expand_node(ptr, pos, self.params, self.policy, 1, 0);
 
             let root_eval = pos.get_value_wdl(self.value, self.params);
-            self.tree[ptr].update(1.0 - root_eval);
+            self.tree.update_node_stats(ptr, 1.0 - root_eval, 0);
         }
         // relabel preexisting root policies with root PST value
         else if self.tree[node].has_children() {
@@ -370,6 +370,8 @@ impl<'a> Searcher<'a> {
                 self.tree.flip(true, threads);
             }
         }
+
+        self.tree.flush_root_accumulator();
 
         *update_nodes += search_stats.total_nodes();
 

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -102,7 +102,7 @@ pub fn perform_one(
 
     // flip perspective and backpropagate
     u = 1.0 - u;
-    node.update(u);
+    tree.update_node_stats(ptr, u, thread_id);
     Some(u)
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -5,9 +5,11 @@ mod node;
 
 use half::TreeHalf;
 use hash::{HashEntry, HashTable};
+use node::NodeStatsDelta;
 pub use node::{Node, NodePtr};
 
 use std::{
+    cell::UnsafeCell,
     mem::MaybeUninit,
     ops::Index,
     sync::atomic::{AtomicBool, AtomicI16, Ordering},
@@ -21,6 +23,109 @@ use crate::{
 
 const NUM_SIDES: usize = 2;
 const NUM_SQUARES: usize = 64;
+const ROOT_ACCUM_THRESHOLD: u32 = 32;
+const ROOT_ACCUM_EAGER_LIMIT: u32 = 256;
+
+#[repr(align(64))]
+struct RootAccumulatorEntry {
+    pending: UnsafeCell<NodeStatsDelta>,
+}
+
+unsafe impl Sync for RootAccumulatorEntry {}
+
+impl RootAccumulatorEntry {
+    fn new() -> Self {
+        Self {
+            pending: UnsafeCell::new(NodeStatsDelta::default()),
+        }
+    }
+
+    unsafe fn add(&self, delta: NodeStatsDelta) -> Option<NodeStatsDelta> {
+        let pending = &mut *self.pending.get();
+        *pending += delta;
+
+        if pending.visits >= ROOT_ACCUM_THRESHOLD {
+            let flush = *pending;
+            *pending = NodeStatsDelta::default();
+            Some(flush)
+        } else {
+            None
+        }
+    }
+
+    unsafe fn take(&self) -> NodeStatsDelta {
+        let pending = &mut *self.pending.get();
+        let flush = *pending;
+        *pending = NodeStatsDelta::default();
+        flush
+    }
+
+    unsafe fn reset(&self) {
+        *self.pending.get() = NodeStatsDelta::default();
+    }
+}
+
+struct RootAccumulator {
+    entries: Vec<RootAccumulatorEntry>,
+}
+
+impl RootAccumulator {
+    fn new(threads: usize) -> Self {
+        Self {
+            entries: (0..threads).map(|_| RootAccumulatorEntry::new()).collect(),
+        }
+    }
+
+    fn add(&self, root: &Node, delta: NodeStatsDelta, thread_id: usize) {
+        if delta.is_empty() {
+            return;
+        }
+
+        if thread_id >= self.entries.len() {
+            root.apply_delta(delta);
+            return;
+        }
+
+        if root.visits() < ROOT_ACCUM_EAGER_LIMIT {
+            root.apply_delta(delta);
+            return;
+        }
+
+        unsafe {
+            if let Some(flush) = self.entries[thread_id].add(delta) {
+                root.apply_delta(flush);
+            }
+        }
+    }
+
+    fn flush_thread(&self, root: &Node, thread_id: usize) {
+        if thread_id >= self.entries.len() {
+            return;
+        }
+
+        unsafe {
+            let pending = self.entries[thread_id].take();
+
+            if !pending.is_empty() {
+                root.apply_delta(pending);
+            }
+        }
+    }
+
+    fn flush_all(&self, root: &Node) {
+        for thread_id in 0..self.entries.len() {
+            self.flush_thread(root, thread_id);
+        }
+    }
+
+    fn reset(&self) {
+        for entry in &self.entries {
+            unsafe {
+                entry.reset();
+            }
+        }
+    }
+}
 
 struct ButterflyTable {
     data: Vec<AtomicI16>,
@@ -89,6 +194,7 @@ pub struct Tree {
     half: AtomicBool,
     hash: HashTable,
     butterfly: ButterflyTable,
+    root_accumulator: RootAccumulator,
 }
 
 impl Index<NodePtr> for Tree {
@@ -121,6 +227,7 @@ impl Tree {
             half: AtomicBool::new(false),
             hash: HashTable::new(hash_cap / 4, threads),
             butterfly: ButterflyTable::new(),
+            root_accumulator: RootAccumulator::new(threads),
         }
     }
 
@@ -162,6 +269,8 @@ impl Tree {
     pub fn flip(&self, copy_across: bool, threads: usize) {
         let old_root_ptr = self.root_node();
 
+        self.root_accumulator.flush_all(&self[old_root_ptr]);
+
         let old = usize::from(self.half.fetch_xor(true, Ordering::Relaxed));
         self.tree[old].clear_ptrs(threads);
         self.tree[old ^ 1].clear();
@@ -172,6 +281,8 @@ impl Tree {
 
             self.copy_node_across(old_root_ptr, new_root_ptr);
         }
+
+        self.reset_root_accumulator();
     }
 
     #[must_use]
@@ -210,6 +321,24 @@ impl Tree {
         self.hash.push(hash, wins);
     }
 
+    pub fn update_node_stats(&self, ptr: NodePtr, value: f32, thread_id: usize) {
+        if ptr == self.root_node() {
+            let delta = NodeStatsDelta::from_value(value);
+            self.root_accumulator.add(&self[ptr], delta, thread_id);
+        } else {
+            self[ptr].update(value);
+        }
+    }
+
+    pub fn flush_root_accumulator(&self) {
+        let root = self.root_node();
+        self.root_accumulator.flush_all(&self[root]);
+    }
+
+    fn reset_root_accumulator(&self) {
+        self.root_accumulator.reset();
+    }
+
     fn clear_halves(&self) {
         self.tree[0].clear();
         self.tree[1].clear();
@@ -220,6 +349,7 @@ impl Tree {
         self.clear_halves();
         self.hash.clear(threads);
         self.butterfly.clear();
+        self.root_accumulator.reset();
     }
 
     pub fn is_empty(&self) -> bool {
@@ -385,6 +515,9 @@ impl Tree {
     pub fn set_root_position(&mut self, new_root: &ChessState) {
         let old_root = self.root.clone();
         self.root = new_root.clone();
+
+        self.flush_root_accumulator();
+        self.reset_root_accumulator();
 
         if self.is_empty() {
             return;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -86,6 +86,7 @@ impl RootAccumulator {
             return;
         }
 
+        // This is to prevent a 4 Elo loss in datagen conditions
         if root.visits() < ROOT_ACCUM_EAGER_LIMIT {
             root.apply_delta(delta);
             return;

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,5 +1,5 @@
 use std::{
-    ops::Add,
+    ops::{Add, AddAssign},
     sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering},
 };
 
@@ -45,6 +45,36 @@ impl Add<usize> for NodePtr {
 
     fn add(self, rhs: usize) -> Self::Output {
         Self(self.0 + rhs as u32)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct NodeStatsDelta {
+    pub(crate) visits: u32,
+    pub(crate) sum_q: u64,
+    pub(crate) sum_sq_q: u64,
+}
+
+impl NodeStatsDelta {
+    pub(crate) fn from_value(q: f32) -> Self {
+        let q = (f64::from(q) * f64::from(QUANT)) as u64;
+        Self {
+            visits: 1,
+            sum_q: q,
+            sum_sq_q: q * q,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.visits == 0 && self.sum_q == 0 && self.sum_sq_q == 0
+    }
+}
+
+impl AddAssign for NodeStatsDelta {
+    fn add_assign(&mut self, rhs: Self) {
+        self.visits = self.visits.saturating_add(rhs.visits);
+        self.sum_q = self.sum_q.saturating_add(rhs.sum_q);
+        self.sum_sq_q = self.sum_sq_q.saturating_add(rhs.sum_sq_q);
     }
 }
 
@@ -215,13 +245,26 @@ impl Node {
         self.threads.store(0, Ordering::Relaxed);
     }
 
-    pub fn update(&self, q: f32) -> f32 {
-        let q = (f64::from(q) * f64::from(QUANT)) as u64;
-        let old_v = self.visits.fetch_add(1, Ordering::Relaxed);
-        let old_q = self.sum_q.fetch_add(q, Ordering::Relaxed);
-        self.sum_sq_q.fetch_add(q * q, Ordering::Relaxed);
+    pub fn update(&self, q: f32) {
+        self.apply_delta(NodeStatsDelta::from_value(q));
+    }
 
-        (((q + old_q) / u64::from(1 + old_v)) as f64 / f64::from(QUANT)) as f32
+    pub(crate) fn apply_delta(&self, delta: NodeStatsDelta) {
+        if delta.is_empty() {
+            return;
+        }
+
+        if delta.visits > 0 {
+            self.visits.fetch_add(delta.visits, Ordering::Relaxed);
+        }
+
+        if delta.sum_q > 0 {
+            self.sum_q.fetch_add(delta.sum_q, Ordering::Relaxed);
+        }
+
+        if delta.sum_sq_q > 0 {
+            self.sum_sq_q.fetch_add(delta.sum_sq_q, Ordering::Relaxed);
+        }
     }
 
     #[cfg(feature = "datagen")]


### PR DESCRIPTION
Introduce per-thread root accumulation and NodeStatsDelta batching so multi-threaded searches update root statistics with lower contention. Route root updates through the accumulator during playouts and flush on search completion/tree maintenance to keep data consistent across flips. This patch was verified in its current form to have no fixed nodes elo loss at any node count. The eager limit prevents a 4 Elo loss in datagen conditions.

Passed Non-Reg STC:
LLR: 2.93 (-2.94,2.94) <-3.50,0.50>
Total: 8832 W: 2164 L: 2038 D: 4630
Ptnml(0-2): 114, 981, 2093, 1121, 107
https://tests.montychess.org/tests/view/68d1f57256f229dd4390f2a8

Passed Non-Reg SMP STC:
LLR: 2.99 (-2.94,2.94) <-3.50,0.50>
Total: 13768 W: 3149 L: 3044 D: 7575
Ptnml(0-2): 74, 1535, 3572, 1618, 85
https://tests.montychess.org/tests/view/68d1f6f556f229dd4390f2ae

128 Thread performance (EPYC 9654 x2):

setoption name Threads value 128
setoption name Hash value 64000
go movetime 10000

master:
info depth 14 seldepth 48 score cp 2 time 10009 nodes 206294983 nps 20610260 pv d2d4 g8f6 c2c4 e7e6 b1c3 f8b4 d1c2 e8g8 g1f3 d7d5 c4d5 e6d5 c1g5 c7c5

patch:
info depth 15 seldepth 45 score cp 2 time 10023 nodes 235119615 nps 23457534 pv d2d4 g8f6 c2c4 e7e6 g2g3 d7d5 f1g2 f8e7 g1f3 e8g8 e1g1 d5c4 f3e5 b8c6 g2c6

**Speedup: 14.0%**

Bench: 1243298