### PR TITLE
New Value Network: `nn-c1dd869bed55.network`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,34 +1,38 @@
+name: Basic Checks
+
 on:
-  pull_request:
   push:
     branches:
       - master
+  pull_request:
 
-
-name: Basic Checks
 jobs:
   check:
     name: cargo check
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
-        - run: cargo check
-        - run: cargo check --package datagen
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check --locked
+      - run: cargo check --package datagen --locked
 
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
-        - run: cargo clippy -- -D warnings
-        - run: cargo clippy --package datagen -- -D warnings
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --package datagen -- -D warnings
 
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
-        - run: cargo fmt --all -- --check
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -10,7 +10,7 @@ use super::{
 #[allow(non_upper_case_globals, dead_code)]
 pub const ValueFileDefaultName: &str = "nn-09da29a4b6ed.network";
 #[allow(non_upper_case_globals, dead_code)]
-pub const CompressedValueName: &str = "nn-fa1a8afd872c.network";
+pub const CompressedValueName: &str = "nn-c1dd869bed55.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
 

--- a/src/networks/value.rs
+++ b/src/networks/value.rs
@@ -8,7 +8,7 @@ use super::{
 
 // DO NOT MOVE
 #[allow(non_upper_case_globals, dead_code)]
-pub const ValueFileDefaultName: &str = "nn-58274aa39e13.network";
+pub const ValueFileDefaultName: &str = "nn-09da29a4b6ed.network";
 #[allow(non_upper_case_globals, dead_code)]
 pub const CompressedValueName: &str = "nn-fa1a8afd872c.network";
 #[allow(non_upper_case_globals, dead_code)]
@@ -17,7 +17,7 @@ pub const DatagenValueFileName: &str = "nn-5601bb8c241d.network";
 const QA: i16 = 128;
 const QB: i16 = 1024;
 
-const L1: usize = 3072;
+const L1: usize = 8192;
 
 #[repr(C, align(64))]
 pub struct ValueNetwork {


### PR DESCRIPTION
Upgrades value net L1 from 3072 to 8192. Trained for 1.6B games (MontyValue7 on HF) for 12k SB. 1 week on 1xB200.

Fixed nodes:
```Results of Patch vs Baseline (1000 nodes, 1t, 64MB, UHO_Lichess_4852_v1.epd):
Elo: 79.68 +/- 4.70, nElo: 119.62 +/- 6.81
LOS: 100.00 %, DrawRatio: 36.02 %, PairsRatio: 3.36
Games: 10000, Wins: 4105, Losses: 1851, Draws: 4044, Points: 6127.0 (61.27 %)
Ptnml(0-2): [90, 643, 1801, 1855, 611], WL/DD Ratio: 1.33
```

Passed LTC:
LLR: 2.95 (-2.94,2.94) <0.00,4.00>
Total: 70368 W: 16520 L: 16157 D: 37691
Ptnml(0-2): 519, 8376, 17002, 8797, 490
https://tests.montychess.org/tests/view/68d5e6bd56f229dd4390f2b4

Passed VVLTC:
LLR: 2.95 (-2.94,2.94) <1.00,5.00>
Total: 2174 W: 519 L: 386 D: 1269
Ptnml(0-2): 2, 177, 599, 304, 5
https://tests.montychess.org/tests/view/68d5e99756f229dd4390f2b8

Bench: 1119942