### PR TITLE
8 byte pointers and 64 byte nodes

### DIFF
--- a/datagen/src/thread.rs
+++ b/datagen/src/thread.rs
@@ -140,7 +140,8 @@ impl<'a> DatagenThread<'a> {
                 for action in 0..tree[tree.root_node()].num_actions() {
                     let node = &tree[actions + action];
                     let mov = montyformat::chess::Move::from(u16::from(node.parent_move()));
-                    dist.push((mov, node.visits()));
+                    let visits = node.visits().min(u32::MAX as u64) as u32;
+                    dist.push((mov, visits));
                 }
 
                 assert_eq!(root_count, dist.len());

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -177,7 +177,7 @@ impl<'a> Searcher<'a> {
 
                 for (action, visits) in visit_dist.iter_mut().enumerate() {
                     let v = self.tree[child_ptr + action].visits();
-                    // Saturate to i32::MAX (works whether visits() is u32 or usize)
+                    // Saturate to i32::MAX (works whether visits() is u32, u64, or usize)
                     let v_i32 = (v as i64).min(i32::MAX as i64) as i32;
                     *visits = v_i32;
                 }

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -177,7 +177,7 @@ impl<'a> Searcher<'a> {
 
                 for (action, visits) in visit_dist.iter_mut().enumerate() {
                     let v = self.tree[child_ptr + action].visits();
-                    // Saturate to i32::MAX (works whether visits() is u32, u64, or usize)
+                    // Saturate to i32::MAX (works whether visits() is u64, or usize)
                     let v_i32 = (v as i64).min(i32::MAX as i64) as i32;
                     *visits = v_i32;
                 }

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -147,7 +147,7 @@ fn pick_action(searcher: &Searcher, ptr: NodePtr, node: &Node) -> usize {
             // virtual loss
             let threads = f64::from(child.threads());
             if threads > 0.0 {
-                let visits = f64::from(child.visits());
+                let visits = child.visits() as f64;
                 let q2 = f64::from(q) * visits
                     / (visits + 1.0 + searcher.params.virtual_loss_weight() * (threads - 1.0));
                 q = q2 as f32;

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -132,10 +132,10 @@ fn pick_action(searcher: &Searcher, ptr: NodePtr, node: &Node) -> usize {
         k += 1;
     }
     let mut limit = k.max(searcher.params.min_policy_actions() as usize);
-    let mut thresh = 1u32 << (searcher.params.visit_threshold_power() as u32);
+    let mut thresh = 1u64 << (searcher.params.visit_threshold_power() as u32);
     while node.visits() >= thresh && limit < node.num_actions() {
         limit += 2;
-        thresh = thresh.checked_shl(1).unwrap_or(u32::MAX);
+        thresh = thresh.checked_shl(1).unwrap_or(u64::MAX);
     }
     limit = limit.min(node.num_actions());
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -211,11 +211,13 @@ impl Tree {
         let bytes = mb * 1024 * 1024;
 
         const _: () = assert!(
-            std::mem::size_of::<Node>() == 40,
+            std::mem::size_of::<Node>() == 48,
             "You must reconsider this allocation!"
         );
 
-        Self::new(bytes / 42, bytes / 42 / 16, threads)
+        let node_bytes = std::mem::size_of::<Node>() + 2;
+
+        Self::new(bytes / node_bytes, bytes / node_bytes / 16, threads)
     }
 
     fn new(tree_cap: usize, hash_cap: usize, threads: usize) -> Self {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -23,8 +23,8 @@ use crate::{
 
 const NUM_SIDES: usize = 2;
 const NUM_SQUARES: usize = 64;
-const ROOT_ACCUM_THRESHOLD: u32 = 32;
-const ROOT_ACCUM_EAGER_LIMIT: u32 = 256;
+const ROOT_ACCUM_THRESHOLD: u64 = 32;
+const ROOT_ACCUM_EAGER_LIMIT: u64 = 256;
 
 #[repr(align(64))]
 struct RootAccumulatorEntry {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -642,7 +642,7 @@ impl Tree {
 
         for i in 0..node.num_actions() {
             let child = &self[child_ptr + i];
-            distribution[i] = f64::from(child.visits()).powf(t);
+            distribution[i] = (child.visits() as f64).powf(t);
             total += distribution[i];
         }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -211,7 +211,7 @@ impl Tree {
         let bytes = mb * 1024 * 1024;
 
         const _: () = assert!(
-            std::mem::size_of::<Node>() == 48,
+            std::mem::size_of::<Node>() == 56,
             "You must reconsider this allocation!"
         );
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -211,7 +211,7 @@ impl Tree {
         let bytes = mb * 1024 * 1024;
 
         const _: () = assert!(
-            std::mem::size_of::<Node>() == 56,
+            std::mem::size_of::<Node>() == 64,
             "You must reconsider this allocation!"
         );
 

--- a/src/tree/half.rs
+++ b/src/tree/half.rs
@@ -69,10 +69,10 @@ impl TreeHalf {
             end = start + block;
             self.next[thread].store(next + num, Ordering::Relaxed);
             self.end[thread].store(end, Ordering::Relaxed);
-            Some(NodePtr::new(self.half, start as u32))
+            Some(NodePtr::new(self.half, start))
         } else {
             self.next[thread].store(next + num, Ordering::Relaxed);
-            Some(NodePtr::new(self.half, next as u32))
+            Some(NodePtr::new(self.half, next))
         }
     }
 

--- a/src/tree/lock.rs
+++ b/src/tree/lock.rs
@@ -1,10 +1,10 @@
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use super::NodePtr;
 
 #[derive(Debug)]
 pub struct CustomLock {
-    value: AtomicU32,
+    value: AtomicU64,
     write_locked: AtomicBool,
 }
 
@@ -35,7 +35,7 @@ impl WriteGuard<'_> {
 impl CustomLock {
     pub fn new(val: NodePtr) -> Self {
         Self {
-            value: AtomicU32::new(val.inner()),
+            value: AtomicU64::new(val.inner()),
             write_locked: AtomicBool::new(false),
         }
     }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,7 +1,7 @@
 use std::{
     convert::TryFrom,
     ops::{Add, AddAssign},
-    sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering},
+    sync::atomic::{AtomicU16, AtomicU64, AtomicU8, Ordering},
 };
 
 use crate::chess::{GameState, Move};
@@ -57,7 +57,7 @@ impl Add<usize> for NodePtr {
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct NodeStatsDelta {
-    pub visits: u32,
+    pub visits: u64,
     pub sum_q: u64,
     pub sum_sq_q: u64,
 }
@@ -93,7 +93,7 @@ pub struct Node {
     threads: AtomicU16,
     mov: AtomicU16,
     policy: AtomicU16,
-    visits: AtomicU32,
+    visits: AtomicU64,
     sum_q: AtomicU64,
     sum_sq_q: AtomicU64,
     gini_impurity: AtomicU8,
@@ -108,7 +108,7 @@ impl Node {
             threads: AtomicU16::new(0),
             mov: AtomicU16::new(0),
             policy: AtomicU16::new(0),
-            visits: AtomicU32::new(0),
+            visits: AtomicU64::new(0),
             sum_q: AtomicU64::new(0),
             sum_sq_q: AtomicU64::new(0),
             gini_impurity: AtomicU8::new(0),
@@ -137,7 +137,7 @@ impl Node {
         self.threads.load(Ordering::Relaxed)
     }
 
-    pub fn visits(&self) -> u32 {
+    pub fn visits(&self) -> u64 {
         self.visits.load(Ordering::Relaxed)
     }
 
@@ -150,7 +150,7 @@ impl Node {
 
         let sum_q = self.sum_q.load(Ordering::Relaxed);
 
-        (sum_q / u64::from(visits)) as f64 / f64::from(QUANT)
+        (sum_q / visits) as f64 / f64::from(QUANT)
     }
 
     pub fn q(&self) -> f32 {
@@ -160,7 +160,7 @@ impl Node {
     pub fn sq_q(&self) -> f64 {
         let sum_sq_q = self.sum_sq_q.load(Ordering::Relaxed);
         let visits = self.visits.load(Ordering::Relaxed);
-        (sum_sq_q / u64::from(visits)) as f64 / f64::from(QUANT).powi(2)
+        (sum_sq_q / visits) as f64 / f64::from(QUANT).powi(2)
     }
 
     pub fn var(&self) -> f32 {

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -56,6 +56,7 @@ impl Add<usize> for NodePtr {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
+#[repr(align(64))]
 pub struct NodeStatsDelta {
     pub visits: u64,
     pub sum_q: u64,
@@ -86,6 +87,7 @@ impl AddAssign for NodeStatsDelta {
 }
 
 #[derive(Debug)]
+#[repr(align(64))]
 pub struct Node {
     actions: CustomLock,
     num_actions: AtomicU8,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -339,7 +339,7 @@ fn go(
     stored_message: &mut Option<String>,
     #[cfg(feature = "datagen")] temp: f32,
 ) {
-    let mut max_nodes = i32::MAX as usize;
+    let mut max_nodes = usize::MAX;
     let mut max_time = None;
     let mut max_depth = 256;
 


### PR DESCRIPTION
Allows long searches with high hash:

setoption name Hash value 384000
setoption name Threads value 384
position fen rnbqkbnr/pppppppp/8/8/6P1/8/PPPPPP1P/RNBQKBNR b KQkq - 0 1
go infinite

info depth 32 seldepth 120 score cp 152 time 92254087 nodes 2808703365580 nps 30445300 pv d7d5 g4g5 e7e5 d2d4 e5d4 g1f3 f8b4 c1d2 b4d6 f3d4 g8e7 c2c4 c7c5 d4b5 d6e5 c4d5 d8d5 h1g1 b8c6 d2c3 c6d4 f1g2 d5d7 b1a3 e8g8 e2e3 e7f5 d1d2 f5h4 e1c1 h4g2 g1g2

Also a speedup at high thread counts due to cache line allignment:
128 Thread performance (EPYC 9654 x2):

setoption name Threads value 128
setoption name Hash value 64000
go movetime 10000

master:
info depth 15 seldepth 49 score cp 3 time 10001 nodes 205595399 nps 20555558 pv d2d4 g8f6 c2c4 e7e6 b1c3 f8b4 d1c2 e8g8 e2e4 d7d5 e4e5 f6e4 f1d3 c7c5 g1f3

patch:
info depth 14 seldepth 49 score cp 2 time 10000 nodes 234156326 nps 23413428 pv c2c4 e7e5 g2g3 c7c6 g1f3 e5e4 f3d4 d8b6 d4b3 a7a5 d2d3 g8f6 f1g2 f8b4

**Speedup: 13.9%**

Loses Elo at low hash conditions like CCRL blitz:
LTC Non-Reg:
LLR: -2.94 (-2.94,2.94) <-3.50,0.50>
Total: 7536 W: 1517 L: 1666 D: 4353
Ptnml(0-2): 39, 931, 1971, 794, 33
https://tests.montychess.org/tests/view/68da7b8bf2c8ac2e3f959d46

Bench: 1124628
