### PR TITLE
Batch update nodes near root also

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -145,14 +145,16 @@ impl RootAccumulator {
                 return Some(idx);
             }
 
-            if current == NodePtr::NULL.inner() && slot
+            if current == NodePtr::NULL.inner()
+                && slot
                     .compare_exchange(
                         NodePtr::NULL.inner(),
                         BATCH_SLOT_RESERVED,
                         Ordering::AcqRel,
                         Ordering::Relaxed,
                     )
-                    .is_ok() {
+                    .is_ok()
+            {
                 self.clear_slot(idx);
                 slot.store(inner, Ordering::Release);
                 return Some(idx);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -145,20 +145,17 @@ impl RootAccumulator {
                 return Some(idx);
             }
 
-            if current == NodePtr::NULL.inner() {
-                if slot
+            if current == NodePtr::NULL.inner() && slot
                     .compare_exchange(
                         NodePtr::NULL.inner(),
                         BATCH_SLOT_RESERVED,
                         Ordering::AcqRel,
                         Ordering::Relaxed,
                     )
-                    .is_ok()
-                {
-                    self.clear_slot(idx);
-                    slot.store(inner, Ordering::Release);
-                    return Some(idx);
-                }
+                    .is_ok() {
+                self.clear_slot(idx);
+                slot.store(inner, Ordering::Release);
+                return Some(idx);
             }
         }
 


### PR DESCRIPTION
Whenever nodes pass 16384 visits add them to the batched nodes list up to a maximum of 32 batched nodes.

128 Thread performance (EPYC 9654 x2):

setoption name Hash value 64000
setoption name Threads value 128
go movetime 10000

master:
info depth 14 seldepth 47 score cp 2 time 10005 nodes 228251555 nps 22812340 pv d2d4 g8f6 c2c4 e7e6 b1c3 f8b4 d1c2 e8g8 e2e4 d7d5 e4e5 f6e4 g1f3 c7c5

patch:
info depth 15 seldepth 47 score cp 2 time 10007 nodes 267045922 nps 26683342 pv d2d4 g8f6 c2c4 e7e6 b1c3 f8b4 e2e3 e8g8 f1d3 d7d5 c4d5 e6d5 g1e2 f8e8 e1g1

**Speedup: +17.0%**

Passed Non-Reg STC:
LLR: 2.91 (-2.94,2.94) <-3.50,0.50>
Total: 72064 W: 17160 L: 17194 D: 37710
Ptnml(0-2): 944, 8578, 17014, 8560, 936
https://tests.montychess.org/tests/view/68dba886f2c8ac2e3f959d5b

Minor elo loss at ultra short TCs and high threads.

Bench: 1124606