### PR TITLE
Move policy trainer code into repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,11 @@
 *.binpack
 *.exe
 *.pdb
+*.bin
 *.network
 *.epd
 *.zst
-checkpoints
-data
+/checkpoints
+/data
 nets
 monty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "acyclib"
 version = "0.3.0"
-source = "git+https://github.com/jw1912/bullet?rev=36837b4788312dd123b59826230f357d12b68fd2#36837b4788312dd123b59826230f357d12b68fd2"
+source = "git+https://github.com/jw1912/bullet?rev=0891eca1fa3316db0d009df7146f85eab04407c2#0891eca1fa3316db0d009df7146f85eab04407c2"
 dependencies = [
  "parking_lot",
  "rand",
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "bullet_cuda_backend"
 version = "0.1.0"
-source = "git+https://github.com/jw1912/bullet?rev=36837b4788312dd123b59826230f357d12b68fd2#36837b4788312dd123b59826230f357d12b68fd2"
+source = "git+https://github.com/jw1912/bullet?rev=0891eca1fa3316db0d009df7146f85eab04407c2#0891eca1fa3316db0d009df7146f85eab04407c2"
 dependencies = [
  "acyclib",
  "cudarc",
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "bullet_hip_backend"
 version = "0.1.0"
-source = "git+https://github.com/jw1912/bullet?rev=36837b4788312dd123b59826230f357d12b68fd2#36837b4788312dd123b59826230f357d12b68fd2"
+source = "git+https://github.com/jw1912/bullet?rev=0891eca1fa3316db0d009df7146f85eab04407c2#0891eca1fa3316db0d009df7146f85eab04407c2"
 dependencies = [
  "acyclib",
  "cc",
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "bullet_lib"
 version = "1.0.0"
-source = "git+https://github.com/jw1912/bullet?rev=36837b4788312dd123b59826230f357d12b68fd2#36837b4788312dd123b59826230f357d12b68fd2"
+source = "git+https://github.com/jw1912/bullet?rev=0891eca1fa3316db0d009df7146f85eab04407c2#0891eca1fa3316db0d009df7146f85eab04407c2"
 dependencies = [
  "acyclib",
  "bullet_cuda_backend",
@@ -634,6 +634,16 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "train-policy"
+version = "0.1.0"
+dependencies = [
+ "acyclib",
+ "bullet_cuda_backend",
+ "monty",
+ "montyformat 0.10.0",
+]
 
 [[package]]
 name = "train-value"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ chrono = "0.4.38"
 zstd = { version = "0.13.2", features = ["zstdmt"] }
 
 [workspace]
-members = ["crates/datagen", "crates/montyformat", "crates/train-value"]
+members = ["crates/datagen", "crates/montyformat", "crates/train-policy", "crates/train-value"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ There are a number of other crates found in [crates/](crates/):
     - Intended to be ran on montytest, there is no need to run it locally (unless testing changes)
 - [`train-value`](crates/train-value/)
     - Uses [bullet](https://github.com/jw1912/bullet)
+- [`train-policy`](crates/train-policy/)
+    - Uses [bullet](https://github.com/jw1912/bullet) & extends it with custom operations
 
 ## Terms of use
 

--- a/crates/train-policy/Cargo.toml
+++ b/crates/train-policy/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "train-policy"
+version = "0.1.0"
+edition = { workspace = true }
+authors = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+default-run = "train-policy"
+
+[dependencies]
+acyclib = { package = "acyclib", git = 'https://github.com/jw1912/bullet', rev = "0891eca1fa3316db0d009df7146f85eab04407c2" }
+bullet_cuda_backend = { package = "bullet_cuda_backend", git = 'https://github.com/jw1912/bullet', rev = "0891eca1fa3316db0d009df7146f85eab04407c2" }
+montyformat = { workspace = true }
+monty = { workspace = true }

--- a/crates/train-policy/src/bin/convert.rs
+++ b/crates/train-policy/src/bin/convert.rs
@@ -1,0 +1,54 @@
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+};
+
+use montyformat::{MontyFormat, MontyValueFormat};
+
+fn main() {
+    let mut args = std::env::args();
+    args.next();
+
+    let inp_path = args.next().unwrap();
+    let out_path = args.next().unwrap();
+
+    let mut reader = BufReader::new(File::open(inp_path).unwrap());
+    let mut writer = BufWriter::new(File::create(out_path).unwrap());
+
+    let mut positions = 0;
+    let mut games = 0;
+
+    let mut moves = Vec::new();
+
+    while let Ok(game) = MontyFormat::deserialise_from(&mut reader) {
+        moves.clear();
+
+        let mut value = MontyValueFormat {
+            startpos: game.startpos,
+            castling: game.castling,
+            result: game.result,
+            moves,
+        };
+
+        let mut stm = value.startpos.stm();
+
+        for result in game.moves {
+            positions += 1;
+            value.push(stm, result.best_move, result.score);
+            stm = 1 - stm;
+        }
+
+        MontyValueFormat::serialise_into(&value, &mut writer).unwrap();
+
+        games += 1;
+        moves = value.moves;
+
+        if games % 16384 == 0 {
+            println!("Converted {games} games.");
+        }
+    }
+
+    println!("Positions    : {positions}");
+    println!("Games        : {games}");
+    println!("Avg Game Len : {:.2}", positions as f64 / games as f64);
+}

--- a/crates/train-policy/src/bin/interleave.rs
+++ b/crates/train-policy/src/bin/interleave.rs
@@ -1,0 +1,108 @@
+use std::{
+    fs::{self, File},
+    io::{BufReader, BufWriter, Write},
+};
+
+use montyformat::{FastDeserialise, MontyFormat};
+
+fn main() -> std::io::Result<()> {
+    let folder_path = "/home/privateclient/monty_value_training/monty-policy-data"; // Specify the folder to scan
+    let output = "interleaved.binpack";
+
+    // Scan the folder and collect file paths with the specified extension
+    let inputs: Vec<String> = fs::read_dir(folder_path)?
+        .filter_map(|entry| {
+            let entry = entry.expect("Failed to read entry");
+            let path = entry.path();
+            if path.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("binpack") {
+                Some(path.to_string_lossy().into_owned())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    println!("Writing to {output:#?}");
+    println!("Reading from:\n{inputs:#?}");
+    let mut streams = Vec::new();
+    let mut total = 0;
+
+    let target = File::create(output)?;
+    let mut writer = BufWriter::new(target);
+
+    for path in &inputs {
+        let file = File::open(path)?;
+
+        let count = file.metadata()?.len();
+
+        if count > 0 {
+            streams.push((count, BufReader::new(file)));
+            total += count;
+        }
+    }
+
+    let mut remaining = total;
+    let mut rng = RandU64::default();
+
+    const INTERVAL: u64 = 1024 * 1024 * 256;
+    let mut prev = remaining / INTERVAL;
+
+    let mut buffer = Vec::new();
+
+    while remaining > 0 {
+        let mut spot = rng.rand() % remaining;
+        let mut idx = 0;
+        while streams[idx].0 < spot {
+            spot -= streams[idx].0;
+            idx += 1;
+        }
+
+        let (count, reader) = &mut streams[idx];
+
+        MontyFormat::deserialise_fast_into_buffer(reader, &mut buffer)?;
+        writer.write_all(&buffer)?;
+
+        let size = buffer.len() as u64;
+
+        remaining -= size;
+        *count -= size;
+        if *count == 0 {
+            streams.swap_remove(idx);
+        }
+
+        if remaining / INTERVAL < prev {
+            prev = remaining / INTERVAL;
+            let written = total - remaining;
+            print!(
+                "Written {written}/{total} Bytes ({:.2}%)\r",
+                written as f64 / total as f64 * 100.0
+            );
+            let _ = std::io::stdout().flush();
+        }
+    }
+
+    Ok(())
+}
+
+struct RandU64(u64);
+
+impl Default for RandU64 {
+    fn default() -> Self {
+        Self(
+            (std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("valid")
+                .as_nanos()
+                & 0xFFFF_FFFF_FFFF_FFFF) as u64,
+        )
+    }
+}
+
+impl RandU64 {
+    fn rand(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+}

--- a/crates/train-policy/src/data.rs
+++ b/crates/train-policy/src/data.rs
@@ -1,0 +1,4 @@
+pub mod loader;
+pub mod reader;
+
+pub use loader::MontyDataLoader;

--- a/crates/train-policy/src/data/loader.rs
+++ b/crates/train-policy/src/data/loader.rs
@@ -1,0 +1,156 @@
+use acyclib::{
+    device::tensor::Shape,
+    trainer::{
+        dataloader::{
+            DataLoader, HostDenseMatrix, HostMatrix, HostSparseMatrix, PreparedBatchHost,
+        },
+        DataLoadingError,
+    },
+};
+use monty::networks::policy::{
+    inputs::map_features,
+    outputs::{map_move_to_index, NUM_MOVES_INDICES},
+    INPUT_SIZE,
+};
+use montyformat::chess::Move;
+
+use super::reader::{DataReader, DecompressedData};
+use crate::model::{MAX_ACTIVE_BASE, MAX_MOVES};
+
+#[derive(Clone)]
+pub struct MontyDataLoader {
+    reader: DataReader,
+    threads: usize,
+}
+
+impl MontyDataLoader {
+    pub fn new(
+        path: &str,
+        buffer_size_mb: usize,
+        reader_threads: usize,
+        loader_threads: usize,
+    ) -> Self {
+        Self {
+            reader: DataReader::new(path, buffer_size_mb, reader_threads),
+            threads: loader_threads,
+        }
+    }
+}
+
+impl DataLoader for MontyDataLoader {
+    type Error = DataLoadingError;
+
+    fn map_batches<F: FnMut(PreparedBatchHost) -> bool>(
+        self,
+        batch_size: usize,
+        mut f: F,
+    ) -> Result<(), Self::Error> {
+        self.reader
+            .map_batches(batch_size, |batch| f(prepare(batch, self.threads)));
+
+        Ok(())
+    }
+}
+
+pub fn prepare(data: &[DecompressedData], threads: usize) -> PreparedBatchHost {
+    let batch_size = data.len();
+    let chunk_size = batch_size.div_ceil(threads);
+
+    let mut inputs = vec![0; MAX_ACTIVE_BASE * batch_size];
+    let mut moves = vec![0; MAX_MOVES * batch_size];
+    let mut dist = vec![0.0; MAX_MOVES * batch_size];
+
+    std::thread::scope(|s| {
+        for (((data_chunk, input_chunk), moves_chunk), dist_chunk) in data
+            .chunks(chunk_size)
+            .zip(inputs.chunks_mut(MAX_ACTIVE_BASE * chunk_size))
+            .zip(moves.chunks_mut(MAX_MOVES * chunk_size))
+            .zip(dist.chunks_mut(MAX_MOVES * chunk_size))
+        {
+            s.spawn(move || {
+                for (i, point) in data_chunk.iter().enumerate() {
+                    let input_offset = MAX_ACTIVE_BASE * i;
+                    let moves_offset = MAX_MOVES * i;
+
+                    let mut j = 0;
+                    map_features(&point.pos, |feat| {
+                        assert!(feat < INPUT_SIZE);
+                        input_chunk[input_offset + j] = feat as i32;
+                        j += 1;
+                    });
+
+                    for k in j..MAX_ACTIVE_BASE {
+                        input_chunk[input_offset + k] = -1;
+                    }
+
+                    assert!(
+                        j <= MAX_ACTIVE_BASE,
+                        "More inputs provided than the specified maximum!"
+                    );
+
+                    let mut total = 0;
+                    let mut distinct = 0;
+
+                    let pos = &point.pos;
+
+                    for &(mov, visits) in &point.moves[..point.num] {
+                        total += visits;
+
+                        let mov = Move::from(mov);
+                        moves_chunk[moves_offset + distinct] = map_move_to_index(pos, mov) as i32;
+                        dist_chunk[moves_offset + distinct] = f32::from(visits);
+                        distinct += 1;
+                    }
+
+                    for k in distinct..MAX_MOVES {
+                        moves_chunk[moves_offset + k] = -1;
+                    }
+
+                    let total = f32::from(total);
+
+                    for idx in 0..distinct {
+                        dist_chunk[moves_offset + idx] /= total;
+                    }
+                }
+            });
+        }
+    });
+
+    let mut prep = PreparedBatchHost {
+        batch_size,
+        inputs: Default::default(),
+    };
+
+    unsafe {
+        prep.inputs.insert(
+            "inputs".to_string(),
+            HostMatrix::Sparse(HostSparseMatrix::new(
+                inputs,
+                Some(batch_size),
+                Shape::new(INPUT_SIZE, 1),
+                MAX_ACTIVE_BASE,
+            )),
+        );
+
+        prep.inputs.insert(
+            "moves".to_string(),
+            HostMatrix::Sparse(HostSparseMatrix::new(
+                moves,
+                Some(batch_size),
+                Shape::new(NUM_MOVES_INDICES, 1),
+                MAX_MOVES,
+            )),
+        );
+    }
+
+    prep.inputs.insert(
+        "targets".to_string(),
+        HostMatrix::Dense(HostDenseMatrix::new(
+            dist,
+            Some(batch_size),
+            Shape::new(MAX_MOVES, 1),
+        )),
+    );
+
+    prep
+}

--- a/crates/train-policy/src/data/reader.rs
+++ b/crates/train-policy/src/data/reader.rs
@@ -1,0 +1,277 @@
+use std::{
+    fs::File,
+    io::{BufReader, Cursor, Read},
+    sync::mpsc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use montyformat::{
+    chess::{Castling, Move, Position},
+    FastDeserialise, MontyFormat,
+};
+
+use crate::model::MAX_MOVES;
+
+#[derive(Clone, Copy)]
+pub struct DecompressedData {
+    pub pos: Position,
+    pub castling: Castling,
+    pub moves: [(u16, u16); MAX_MOVES],
+    pub num: usize,
+}
+
+#[derive(Clone)]
+pub struct DataReader {
+    file_path: String,
+    buffer_size: usize,
+    threads: usize,
+}
+
+impl DataReader {
+    pub fn new(path: &str, buffer_size_mb: usize, threads: usize) -> Self {
+        Self {
+            file_path: path.to_string(),
+            buffer_size: buffer_size_mb * 1024 * 1024 / std::mem::size_of::<DecompressedData>() / 2,
+            threads,
+        }
+    }
+}
+
+impl DataReader {
+    pub fn map_batches<F: FnMut(&[DecompressedData]) -> bool>(&self, batch_size: usize, mut f: F) {
+        let file_path = self.file_path.clone();
+        let buffer_size = self.buffer_size;
+        let threads = self.threads;
+        let games_per_thread = 2048;
+
+        let (game_sender, game_receiver) = mpsc::sync_channel::<Vec<u8>>(32);
+
+        std::thread::spawn(move || {
+            let mut buffer = Vec::new();
+
+            'dataloading: loop {
+                let mut reader = BufReader::new(File::open(file_path.as_str()).unwrap());
+
+                while let Ok(()) =
+                    MontyFormat::deserialise_fast_into_buffer(&mut reader, &mut buffer)
+                {
+                    if game_sender.send(buffer.clone()).is_err() {
+                        break 'dataloading;
+                    }
+                }
+            }
+        });
+
+        let (mini_sender, mini_receiver) = mpsc::sync_channel::<Vec<DecompressedData>>(threads);
+
+        std::thread::spawn(move || {
+            let mut buffer = Vec::new();
+
+            while let Ok(game_bytes) = game_receiver.recv() {
+                buffer.push(game_bytes);
+                if buffer.len() == games_per_thread * threads {
+                    if std::thread::scope(|s| {
+                        let mut handles = Vec::with_capacity(threads);
+
+                        for chunk in buffer.chunks(games_per_thread) {
+                            let this_sender = mini_sender.clone();
+                            let handle = s.spawn(move || {
+                                let mut buf = Vec::with_capacity(160 * games_per_thread);
+
+                                for game_bytes in chunk {
+                                    parse_into_buffer(game_bytes, &mut buf);
+                                }
+
+                                this_sender.send(buf).is_err()
+                            });
+
+                            handles.push(handle);
+                        }
+
+                        handles.into_iter().any(|x| x.join().unwrap())
+                    }) {
+                        break;
+                    }
+
+                    buffer.clear();
+                }
+            }
+        });
+
+        let (buffer_sender, buffer_receiver) = mpsc::sync_channel::<Vec<DecompressedData>>(0);
+
+        std::thread::spawn(move || {
+            let mut shuffle_buffer = Vec::new();
+            shuffle_buffer.reserve_exact(buffer_size);
+
+            while let Ok(buffer) = mini_receiver.recv() {
+                if shuffle_buffer.len() + buffer.len() < shuffle_buffer.capacity() {
+                    shuffle_buffer.extend_from_slice(&buffer);
+                } else {
+                    let diff = shuffle_buffer.capacity() - shuffle_buffer.len();
+                    shuffle_buffer.extend_from_slice(&buffer[..diff]);
+
+                    if buffer_sender.send(shuffle_buffer).is_err() {
+                        break;
+                    }
+
+                    shuffle_buffer = Vec::new();
+                    shuffle_buffer.reserve_exact(buffer_size);
+                }
+            }
+        });
+
+        let (shuffled_sender, shuffled_receiver) = mpsc::sync_channel::<Vec<DecompressedData>>(0);
+
+        std::thread::spawn(move || {
+            while let Ok(mut inputs) = buffer_receiver.recv() {
+                shuffle(&mut inputs);
+
+                if shuffled_sender.send(inputs).is_err() {
+                    break;
+                }
+            }
+        });
+
+        'dataloading: while let Ok(inputs) = shuffled_receiver.recv() {
+            for batch in inputs.chunks(batch_size) {
+                if f(batch) {
+                    break 'dataloading;
+                }
+            }
+        }
+
+        drop(shuffled_receiver);
+    }
+}
+
+fn shuffle(data: &mut [DecompressedData]) {
+    let mut rng = Rand::with_seed();
+
+    for i in (0..data.len()).rev() {
+        let idx = rng.rng() as usize % (i + 1);
+        data.swap(idx, i);
+    }
+}
+
+macro_rules! read_into_primitive {
+    ($reader:expr, $t:ty) => {{
+        let mut buf = [0u8; std::mem::size_of::<$t>()];
+        $reader.read_exact(&mut buf).unwrap();
+        <$t>::from_le_bytes(buf)
+    }};
+}
+
+fn parse_into_buffer(game: &[u8], buffer: &mut Vec<DecompressedData>) {
+    let mut reader = Cursor::new(game);
+
+    let mut qbbs = [0u64; 4];
+    for bb in &mut qbbs {
+        *bb = read_into_primitive!(reader, u64);
+    }
+
+    let stm = read_into_primitive!(reader, u8);
+    let enp_sq = read_into_primitive!(reader, u8);
+    let rights = read_into_primitive!(reader, u8);
+    let halfm = read_into_primitive!(reader, u8);
+    let fullm = read_into_primitive!(reader, u16);
+
+    let mut bbs = [0; 8];
+
+    let blc = qbbs[0];
+    let rqk = qbbs[1];
+    let nbk = qbbs[2];
+    let pbq = qbbs[3];
+
+    let occ = rqk | nbk | pbq;
+    let pnb = occ ^ qbbs[1];
+    let prq = occ ^ qbbs[2];
+    let nrk = occ ^ qbbs[3];
+
+    bbs[0] = occ ^ blc;
+    bbs[1] = blc;
+    bbs[2] = pnb & prq;
+    bbs[3] = pnb & nrk;
+    bbs[4] = pnb & nbk & pbq;
+    bbs[5] = prq & nrk;
+    bbs[6] = pbq & prq & rqk;
+    bbs[7] = nbk & rqk;
+
+    #[allow(deprecated)]
+    let mut pos = Position::from_raw(bbs, stm > 0, enp_sq, rights, halfm, fullm);
+
+    let mut rook_files = [[0; 2]; 2];
+    for side in &mut rook_files {
+        for rook in side {
+            *rook = read_into_primitive!(reader, u8);
+        }
+    }
+
+    let castling = Castling::from_raw(&pos, rook_files);
+
+    let _result = read_into_primitive!(reader, u8) as f32 / 2.0;
+
+    loop {
+        let best_move = Move::from(read_into_primitive!(reader, u16));
+
+        if best_move == Move::NULL {
+            break;
+        }
+
+        let _score = f32::from(read_into_primitive!(reader, u16)) / f32::from(u16::MAX);
+
+        let num_moves = usize::from(read_into_primitive!(reader, u8));
+
+        if num_moves > 1 && num_moves <= MAX_MOVES {
+            let mut policy_data = DecompressedData {
+                pos,
+                castling,
+                moves: [(0, 0); MAX_MOVES],
+                num: num_moves,
+            };
+
+            let mut count = 0;
+            pos.map_legal_moves(&castling, |mov| {
+                policy_data.moves[count].0 = mov.into();
+                count += 1;
+            });
+
+            assert_eq!(count, num_moves);
+
+            policy_data.moves[..num_moves].sort_by_key(|x| x.0);
+
+            for entry in &mut policy_data.moves[..num_moves] {
+                entry.1 = u16::from(read_into_primitive!(reader, u8));
+            }
+
+            buffer.push(policy_data);
+        } else {
+            for _ in 0..num_moves {
+                let _ = read_into_primitive!(reader, u8);
+            }
+        }
+
+        pos.make(best_move, &castling);
+    }
+}
+
+pub struct Rand(u64);
+
+impl Rand {
+    pub fn with_seed() -> Self {
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Guaranteed increasing.")
+            .as_micros() as u64
+            & 0xFFFF_FFFF;
+
+        Self(seed)
+    }
+
+    pub fn rng(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+}

--- a/crates/train-policy/src/main.rs
+++ b/crates/train-policy/src/main.rs
@@ -1,0 +1,97 @@
+pub mod data;
+pub mod model;
+
+use acyclib::{
+    device::Device,
+    trainer::{
+        optimiser::{
+            adam::{AdamW, AdamWParams},
+            Optimiser,
+        },
+        schedule::{TrainingSchedule, TrainingSteps},
+        Trainer,
+    },
+};
+use bullet_cuda_backend::CudaDevice;
+
+use data::MontyDataLoader;
+
+fn main() {
+    let hl = 16384;
+    let dataloader = MontyDataLoader::new(
+        "/home/privateclient/monty_value_training/interleaved.binpack",
+        96000,
+        4,
+        8,
+    );
+
+    let device = CudaDevice::new(0).unwrap();
+
+    let (graph, node) = model::make(device, hl);
+
+    let params = AdamWParams {
+        decay: 0.01,
+        beta1: 0.9,
+        beta2: 0.999,
+        min_weight: -0.99,
+        max_weight: 0.99,
+    };
+    let optimiser = Optimiser::<_, _, AdamW<_>>::new(graph, params).unwrap();
+
+    let mut trainer = Trainer {
+        optimiser,
+        state: (),
+    };
+
+    let save_rate = 40;
+    let end_superbatch = 800;
+    let initial_lr = 0.001;
+    let final_lr = 0.00001;
+
+    let steps = TrainingSteps {
+        batch_size: 16384,
+        batches_per_superbatch: 6104,
+        start_superbatch: 1,
+        end_superbatch,
+    };
+
+    let schedule = TrainingSchedule {
+        steps,
+        log_rate: 64,
+        lr_schedule: Box::new(|_, sb| {
+            if sb >= end_superbatch {
+                return final_lr;
+            }
+
+            let lambda = sb as f32 / end_superbatch as f32;
+            initial_lr * (final_lr / initial_lr).powf(lambda)
+        }),
+    };
+
+    trainer
+        .train_custom(
+            schedule,
+            dataloader,
+            |_, _, _, _| {},
+            |trainer, superbatch| {
+                if superbatch % save_rate == 0 || superbatch == steps.end_superbatch {
+                    println!("Saving Checkpoint");
+                    let dir = format!("checkpoints/policy-{superbatch}");
+                    let _ = std::fs::create_dir(&dir);
+                    trainer.optimiser.write_to_checkpoint(&dir).unwrap();
+                    model::save_quantised(
+                        &trainer.optimiser.graph,
+                        &format!("{dir}/quantised.bin"),
+                    )
+                    .unwrap();
+                }
+            },
+        )
+        .unwrap();
+
+    model::eval(
+        &mut trainer.optimiser.graph,
+        node,
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    );
+}

--- a/crates/train-policy/src/model.rs
+++ b/crates/train-policy/src/model.rs
@@ -1,0 +1,98 @@
+mod loss;
+mod select_affine;
+
+use acyclib::{
+    device::tensor::Shape,
+    graph::{builder::GraphBuilder, Graph, GraphNodeId, GraphNodeIdTy},
+    trainer::dataloader::PreparedBatchDevice,
+};
+use bullet_cuda_backend::CudaDevice;
+use monty::networks::policy::{outputs::NUM_MOVES_INDICES, INPUT_SIZE};
+use montyformat::chess::{Castling, Move, Position};
+
+pub const MAX_MOVES: usize = 64;
+pub const MAX_ACTIVE_BASE: usize = 32;
+
+use crate::data::{loader::prepare, reader::DecompressedData};
+
+pub fn make(device: CudaDevice, hl: usize) -> (Graph<CudaDevice>, GraphNodeId) {
+    let builder = GraphBuilder::default();
+
+    let inputs = builder.new_sparse_input("inputs", Shape::new(INPUT_SIZE, 1), MAX_ACTIVE_BASE);
+    let targets = builder.new_dense_input("targets", Shape::new(MAX_MOVES, 1));
+    let moves = builder.new_sparse_input("moves", Shape::new(NUM_MOVES_INDICES, 1), MAX_MOVES);
+
+    let l0 = builder.new_affine("l0", INPUT_SIZE, hl);
+    let l1 = builder.new_affine("l1", hl / 2, NUM_MOVES_INDICES);
+
+    let hl = l0.forward(inputs).crelu().pairwise_mul();
+
+    let logits = builder.apply(select_affine::SelectAffine::new(l1, hl, moves));
+
+    let ones = builder.new_constant(Shape::new(1, MAX_MOVES), &[1.0; MAX_MOVES]);
+    let loss = builder.apply(loss::OptimisedSoftmaxCrossEntropy::new(logits, targets));
+    let _ = ones.matmul(loss);
+
+    let node = GraphNodeId::new(loss.annotated_node().idx, GraphNodeIdTy::Ancillary(0));
+    (builder.build(device), node)
+}
+
+pub fn eval(graph: &mut Graph<CudaDevice>, node: GraphNodeId, fen: &str) {
+    let mut castling = Castling::default();
+    let pos = Position::parse_fen(fen, &mut castling);
+
+    let mut moves = [(0, 0); 64];
+    let mut num = 0;
+
+    pos.map_legal_moves(&castling, |mov| {
+        moves[num] = (u16::from(mov), 1);
+        num += 1;
+    });
+
+    let point = DecompressedData {
+        pos,
+        castling,
+        moves,
+        num,
+    };
+
+    let data = prepare(&[point], 1);
+
+    let mut on_device = PreparedBatchDevice::new(vec![graph.device()], &data).unwrap();
+
+    on_device.load_into_graph(graph).unwrap();
+
+    let _ = graph.forward().unwrap();
+
+    let dist = graph.get(node).unwrap().get_dense_vals().unwrap();
+
+    println!();
+    println!("{fen}");
+    for i in 0..num {
+        println!(
+            "{} -> {:.2}%",
+            Move::from(moves[i].0).to_uci(&castling),
+            dist[i] * 100.0
+        )
+    }
+}
+
+pub fn save_quantised(graph: &Graph<CudaDevice>, path: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut file = std::fs::File::create(path).unwrap();
+
+    let mut quant = Vec::new();
+
+    for id in ["l0w", "l0b", "l1w", "l1b"] {
+        let vals = graph.get_weights(id).get_dense_vals().unwrap();
+
+        for x in vals {
+            let q = (x * 128.0).round() as i8;
+            assert_eq!((x * 128.0).round(), f32::from(q));
+            quant.extend_from_slice(&q.to_le_bytes());
+        }
+    }
+
+    file.write_all(&quant)
+}

--- a/crates/train-policy/src/model/loss.rs
+++ b/crates/train-policy/src/model/loss.rs
@@ -1,0 +1,148 @@
+use std::num::NonZeroUsize;
+
+use acyclib::{
+    dag::NodeId,
+    device::{
+        function::{self, DeviceFunction},
+        tensor::Shape,
+    },
+    graph::{
+        builder::GraphBuilderNode,
+        ir::{
+            node::AnnotatedNode,
+            operation::{
+                binary::SoftmaxCrossEntropy, GraphIROperationBase, GraphIROperationCompilable,
+            },
+            GraphIR, GraphIRError,
+        },
+        Graph, GraphNodeIdTy,
+    },
+};
+use bullet_cuda_backend::{
+    kernel::{Expr, Kernel, KernelArgs, KernelInput},
+    CudaDevice, CudaMarker,
+};
+
+use super::MAX_MOVES;
+
+#[derive(Clone, Debug)]
+pub struct OptimisedSoftmaxCrossEntropy(SoftmaxCrossEntropy);
+
+impl OptimisedSoftmaxCrossEntropy {
+    pub fn new<'a>(
+        logits: GraphBuilderNode<'a, CudaMarker>,
+        targets: GraphBuilderNode<'a, CudaMarker>,
+    ) -> Self {
+        Self(SoftmaxCrossEntropy {
+            logits: logits.annotated_node(),
+            targets: targets.annotated_node(),
+        })
+    }
+}
+
+impl GraphIROperationBase<CudaMarker> for OptimisedSoftmaxCrossEntropy {
+    fn nodes(&self) -> Vec<AnnotatedNode> {
+        GraphIROperationBase::<CudaMarker>::nodes(&self.0)
+    }
+
+    fn output_shape(&self, ir: &GraphIR<CudaMarker>) -> Result<Shape, GraphIRError> {
+        assert_eq!(self.0.logits.shape, Shape::new(MAX_MOVES, 1));
+        self.0.output_shape(ir)
+    }
+
+    fn ancillary_buffers(
+        &self,
+        ir: &GraphIR<CudaMarker>,
+    ) -> Result<Vec<(Shape, Option<NonZeroUsize>, bool)>, GraphIRError> {
+        self.0.ancillary_buffers(ir)
+    }
+}
+
+impl GraphIROperationCompilable<CudaMarker> for OptimisedSoftmaxCrossEntropy {
+    fn forward_pass(
+        &self,
+        graph: &Graph<CudaDevice>,
+        output_node: NodeId,
+    ) -> DeviceFunction<CudaDevice> {
+        let logits = graph.get_ref(self.0.logits.idx, GraphNodeIdTy::Values);
+        let targets = graph.get_ref(self.0.targets.idx, GraphNodeIdTy::Values);
+        let smax = graph.get_ref(output_node, GraphNodeIdTy::Ancillary(0));
+        let output = graph.get_ref(output_node, GraphNodeIdTy::Values);
+
+        let mut func = DeviceFunction::default();
+
+        func.push(function::MaybeUpdateBatchSize {
+            input: logits.clone(),
+            output: smax.clone(),
+        });
+        func.push(function::MaybeUpdateBatchSize {
+            input: logits.clone(),
+            output: output.clone(),
+        });
+
+        let threads = 512;
+        let entries_per_block = threads / 32;
+        let batch_size = Expr::Var;
+        let blocks = (batch_size.clone() + entries_per_block - 1) / entries_per_block;
+        let grid_dim = [blocks, Expr::Const(1), Expr::Const(1)];
+        let block_dim = [threads, 1, 1].map(Expr::Const);
+        let shared_mem_bytes = Expr::Const(0);
+
+        let layout = None;
+        let batched = logits.batch_size().is_some();
+        let shape = Shape::new(MAX_MOVES, 1);
+
+        let inputs = vec![
+            KernelInput::Size(batch_size),
+            KernelInput::Slice {
+                slice: logits,
+                layout,
+                mutable: false,
+                batched,
+                shape,
+            },
+            KernelInput::Slice {
+                slice: smax.clone(),
+                layout,
+                mutable: true,
+                batched,
+                shape,
+            },
+        ];
+
+        let args = KernelArgs {
+            inputs,
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+        };
+
+        let code = include_str!("loss/softmax.cu")
+            .lines()
+            .skip(5)
+            .map(|x| format!("{x}\n"))
+            .collect::<String>()
+            .replace("THREADS", &threads.to_string())
+            .replace("SIZE", &MAX_MOVES.to_string());
+
+        let kernel = unsafe { Kernel::new("Softmax".to_string(), code, args) };
+
+        func.push(kernel.unwrap());
+
+        func.push(function::CrossEntropy {
+            a: smax,
+            b: targets,
+            output,
+        });
+
+        func
+    }
+
+    fn backward_pass(
+        &self,
+        graph: &Graph<CudaDevice>,
+        output_node: NodeId,
+    ) -> DeviceFunction<CudaDevice> {
+        GraphIROperationCompilable::<CudaMarker>::backward_pass(&self.0, graph, output_node)
+    }
+}

--- a/crates/train-policy/src/model/loss/softmax.cu
+++ b/crates/train-policy/src/model/loss/softmax.cu
@@ -1,0 +1,54 @@
+#ifndef STUFF
+#define THREADS 512;
+#define SIZE 64
+#endif
+
+constexpr int threads = THREADS;
+constexpr int per_block = threads / 32;
+constexpr int size = SIZE;
+constexpr int per_thread = size / 32;
+
+extern "C" __global__ void kernel(const int k, const float* input, float* output)
+{
+    const int entry = per_block * blockIdx.x + (threadIdx.x / 32);
+    const int widx = threadIdx.x % 32;
+
+    if (entry >= k)
+        return;
+
+    float elems[per_thread];
+
+    elems[0] = input[widx + size * entry];
+    float maximum = elems[0];
+
+    #pragma unroll
+    for (int i = 1; i < per_thread; i++) {
+        elems[i] = input[widx + 32 * i + size * entry];
+        maximum = max(maximum, elems[i]);
+    }
+
+    maximum = max(maximum, __shfl_xor_sync(0xffffffff, maximum, 16));
+    maximum = max(maximum, __shfl_xor_sync(0xffffffff, maximum, 8));
+    maximum = max(maximum, __shfl_xor_sync(0xffffffff, maximum, 4));
+    maximum = max(maximum, __shfl_xor_sync(0xffffffff, maximum, 2));
+    maximum = max(maximum, __shfl_xor_sync(0xffffffff, maximum, 1));
+
+    float denom = 0.0F;
+
+    #pragma unroll
+    for (int i = 0; i < per_thread; i++) {
+        elems[i] = expf(elems[i] - maximum);
+        denom += elems[i];
+    }
+
+    denom += __shfl_xor_sync(0xffffffff, denom, 16);
+    denom += __shfl_xor_sync(0xffffffff, denom, 8);
+    denom += __shfl_xor_sync(0xffffffff, denom, 4);
+    denom += __shfl_xor_sync(0xffffffff, denom, 2);
+    denom += __shfl_xor_sync(0xffffffff, denom, 1);
+
+    #pragma unroll
+    for (int i = 0; i < per_thread; i++) {
+        output[widx + 32 * i + size * entry] = elems[i] / denom;
+    }
+}

--- a/crates/train-policy/src/model/select_affine.rs
+++ b/crates/train-policy/src/model/select_affine.rs
@@ -1,0 +1,275 @@
+use acyclib::{
+    dag::NodeId,
+    device::{
+        function::{DeviceFunction, MaybeUpdateBatchSize},
+        tensor::Shape,
+    },
+    graph::{
+        builder::{Affine, GraphBuilderNode},
+        ir::{
+            node::AnnotatedNode,
+            operation::{util, GraphIROperationBase, GraphIROperationCompilable},
+            BackendMarker, GraphIR, GraphIRError,
+        },
+        Graph, GraphNodeIdTy,
+    },
+};
+use bullet_cuda_backend::{
+    kernel::{Expr, Kernel, KernelArgs, KernelInput},
+    CudaDevice, CudaMarker,
+};
+
+use monty::networks::policy::outputs::NUM_MOVES_INDICES;
+
+use super::MAX_MOVES;
+
+#[derive(Debug)]
+pub struct SelectAffine {
+    weights: AnnotatedNode,
+    biases: AnnotatedNode,
+    input: AnnotatedNode,
+    indices: AnnotatedNode,
+}
+
+impl SelectAffine {
+    pub fn new<'a>(
+        affine: Affine<'a, CudaMarker>,
+        input: GraphBuilderNode<'a, CudaMarker>,
+        indices: GraphBuilderNode<'a, CudaMarker>,
+    ) -> Self {
+        Self {
+            weights: affine
+                .weights
+                .reshape(affine.weights.annotated_node().shape.transpose())
+                .annotated_node(),
+            biases: affine.bias.annotated_node(),
+            input: input.annotated_node(),
+            indices: indices.annotated_node(),
+        }
+    }
+}
+
+impl<B: BackendMarker> GraphIROperationBase<B> for SelectAffine {
+    fn nodes(&self) -> Vec<AnnotatedNode> {
+        vec![self.indices, self.input, self.weights, self.biases]
+    }
+
+    fn output_shape(&self, ir: &GraphIR<B>) -> Result<Shape, GraphIRError> {
+        assert_eq!(
+            self.weights.shape,
+            Shape::new(self.input.shape.rows(), NUM_MOVES_INDICES)
+        );
+        assert_eq!(self.biases.shape, Shape::new(NUM_MOVES_INDICES, 1));
+
+        util::check_same_batching(ir, &[&self.indices, &self.input])?;
+        util::check_dense_eq(ir, &self.input, true)?;
+        util::check_dense_eq(ir, &self.indices, false)?;
+        util::check_dense_eq(ir, &self.weights, true)?;
+        util::check_dense_eq(ir, &self.biases, true)?;
+        util::check_not_batched(ir, &self.weights)?;
+        util::check_not_batched(ir, &self.biases)?;
+
+        Ok(Shape::new(MAX_MOVES, 1))
+    }
+}
+
+impl GraphIROperationCompilable<CudaMarker> for SelectAffine {
+    fn forward_pass(
+        &self,
+        graph: &Graph<CudaDevice>,
+        output_node: NodeId,
+    ) -> DeviceFunction<CudaDevice> {
+        let input = graph.get_ref(self.input.idx, GraphNodeIdTy::Values);
+        let indices = graph.get_ref(self.indices.idx, GraphNodeIdTy::Values);
+        let weights = graph.get_ref(self.weights.idx, GraphNodeIdTy::Values);
+        let biases = graph.get_ref(self.biases.idx, GraphNodeIdTy::Values);
+        let output = graph.get_ref(output_node, GraphNodeIdTy::Values);
+
+        let mut func = DeviceFunction::default();
+
+        func.push(MaybeUpdateBatchSize {
+            input: input.clone(),
+            output: output.clone(),
+        });
+
+        let single_size = input.single_size();
+        let batch_size = Expr::Var;
+        let threads = (single_size / 4).min(512) as i32;
+        let grid_dim = [Expr::Const(64), batch_size, Expr::Const(1)];
+        let block_dim = [threads, 1, 1].map(Expr::Const);
+        let shared_mem_bytes = Expr::Const(4 * threads);
+
+        assert!(
+            (threads as u32).is_power_of_two(),
+            "hl size must be a power of 2"
+        );
+        assert_eq!(MAX_MOVES, 64);
+
+        let layout = None;
+        let mutable = false;
+
+        let inputs = vec![
+            KernelInput::Slice {
+                slice: weights,
+                layout,
+                mutable,
+                batched: false,
+                shape: self.weights.shape,
+            },
+            KernelInput::Slice {
+                slice: biases,
+                layout,
+                mutable,
+                batched: false,
+                shape: self.biases.shape,
+            },
+            KernelInput::Slice {
+                slice: input,
+                layout,
+                mutable,
+                batched: true,
+                shape: self.input.shape,
+            },
+            KernelInput::Slice {
+                slice: indices,
+                layout: Some(64),
+                mutable,
+                batched: true,
+                shape: self.indices.shape,
+            },
+            KernelInput::Slice {
+                slice: output,
+                layout,
+                mutable: true,
+                batched: true,
+                shape: Shape::new(MAX_MOVES, 1),
+            },
+        ];
+
+        let args = KernelArgs {
+            inputs,
+            block_dim,
+            grid_dim,
+            shared_mem_bytes,
+        };
+
+        let code = include_str!("select_affine/fwd.cu")
+            .lines()
+            .skip(5)
+            .map(|x| format!("{x}\n"))
+            .collect::<String>()
+            .replace("THREADS", &threads.to_string())
+            .replace("IN_SIZE", &single_size.to_string());
+
+        let kernel = unsafe { Kernel::new("SelectAffineFwd".to_string(), code, args) };
+
+        func.push(kernel.unwrap());
+
+        func
+    }
+
+    fn backward_pass(
+        &self,
+        graph: &Graph<CudaDevice>,
+        output_node: NodeId,
+    ) -> DeviceFunction<CudaDevice> {
+        let input = graph.get_ref(self.input.idx, GraphNodeIdTy::Values);
+        let indices = graph.get_ref(self.indices.idx, GraphNodeIdTy::Values);
+        let weights = graph.get_ref(self.weights.idx, GraphNodeIdTy::Values);
+        let input_grad = graph.get_ref(self.input.idx, GraphNodeIdTy::Gradients);
+        let weights_grad = graph.get_ref(self.weights.idx, GraphNodeIdTy::Gradients);
+        let biases_grad = graph.get_ref(self.biases.idx, GraphNodeIdTy::Gradients);
+        let output_grad = graph.get_ref(output_node, GraphNodeIdTy::Gradients);
+
+        let mut func = DeviceFunction::default();
+
+        func.push(MaybeUpdateBatchSize {
+            input: output_grad.clone(),
+            output: input_grad.clone(),
+        });
+
+        assert_eq!(MAX_MOVES, 64);
+
+        let single_size = input.single_size();
+        let batch_size = Expr::Var;
+        let threads = (single_size / 4).min(1024) as i32;
+        let grid_dim = [Expr::Const(64), batch_size, Expr::Const(1)];
+        let block_dim = [threads, 1, 1].map(Expr::Const);
+        let shared_mem_bytes = Expr::Const(16 * threads);
+
+        let layout = None;
+        let mutable = false;
+
+        let inputs = vec![
+            KernelInput::Slice {
+                slice: weights,
+                layout,
+                mutable,
+                batched: false,
+                shape: self.weights.shape,
+            },
+            KernelInput::Slice {
+                slice: input,
+                layout,
+                mutable,
+                batched: true,
+                shape: self.input.shape,
+            },
+            KernelInput::Slice {
+                slice: indices,
+                layout: Some(64),
+                mutable,
+                batched: true,
+                shape: self.indices.shape,
+            },
+            KernelInput::Slice {
+                slice: output_grad,
+                layout,
+                mutable,
+                batched: true,
+                shape: Shape::new(MAX_MOVES, 1),
+            },
+            KernelInput::Slice {
+                slice: input_grad,
+                layout,
+                mutable: true,
+                batched: true,
+                shape: self.input.shape,
+            },
+            KernelInput::Slice {
+                slice: weights_grad,
+                layout,
+                mutable: true,
+                batched: false,
+                shape: self.weights.shape,
+            },
+            KernelInput::Slice {
+                slice: biases_grad,
+                layout,
+                mutable: true,
+                batched: false,
+                shape: self.biases.shape,
+            },
+        ];
+
+        let args = KernelArgs {
+            inputs,
+            grid_dim,
+            block_dim,
+            shared_mem_bytes,
+        };
+
+        let code = include_str!("select_affine/bwd.cu")
+            .lines()
+            .skip(4)
+            .map(|x| format!("{x}\n"))
+            .collect::<String>()
+            .replace("IN_SIZE", &single_size.to_string());
+
+        let kernel = unsafe { Kernel::new("SelectAffineBwd".to_string(), code, args) };
+
+        func.push(kernel.unwrap());
+
+        func
+    }
+}

--- a/crates/train-policy/src/model/select_affine/bwd.cu
+++ b/crates/train-policy/src/model/select_affine/bwd.cu
@@ -1,0 +1,67 @@
+#ifndef STUFF
+#define IN_SIZE 1024
+#endif
+
+constexpr int in_size = IN_SIZE;
+
+extern "C" __global__ void kernel(
+    const float* weights,
+    const float* input,
+    const int* moves,
+    const float* output_grad,
+    float* input_grad,
+    float* weights_grad,
+    float* biases_grad
+) {
+    extern __shared__ float sdata[];
+
+    const int batch_size = gridDim.y;
+    const int loc_in_batch = blockIdx.y;
+    const int loc_in_moves = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int locmb = loc_in_batch * 64 + loc_in_moves;
+    const int move = moves[locmb];
+    
+    if (move != -1)
+    {
+        const float grd = output_grad[locmb];
+
+        const float4* tW = reinterpret_cast<const float4*>(weights + in_size * move);
+        const float4* tI = reinterpret_cast<const float4*>(input + in_size * loc_in_batch);
+
+        if (tid == 0) atomicAdd(biases_grad + move, grd);
+
+        for (int idx = tid; idx < in_size / 4; idx += blockDim.x)
+        {
+            const int section = 4 * blockDim.x * (idx / blockDim.x) + tid;
+            const float4 ti = tI[idx];
+            const float4 tw = tW[idx];
+
+            sdata[4 * tid    ] = ti.x;
+            sdata[4 * tid + 1] = ti.y;
+            sdata[4 * tid + 2] = ti.z;
+            sdata[4 * tid + 3] = ti.w;
+            __syncthreads();
+
+            float* tWg = weights_grad + in_size * move + section;
+            atomicAdd(tWg                 , grd * sdata[tid                 ]);
+            atomicAdd(tWg + blockDim.x    , grd * sdata[tid + blockDim.x    ]);
+            atomicAdd(tWg + blockDim.x * 2, grd * sdata[tid + blockDim.x * 2]);
+            atomicAdd(tWg + blockDim.x * 3, grd * sdata[tid + blockDim.x * 3]);
+            __syncthreads();
+
+            sdata[4 * tid    ] = tw.x;
+            sdata[4 * tid + 1] = tw.y;
+            sdata[4 * tid + 2] = tw.z;
+            sdata[4 * tid + 3] = tw.w;
+            __syncthreads();
+
+            float* tIg = input_grad + in_size * loc_in_batch + section;
+            atomicAdd(tIg                 , grd * sdata[tid                 ]);
+            atomicAdd(tIg + blockDim.x    , grd * sdata[tid + blockDim.x    ]);
+            atomicAdd(tIg + blockDim.x * 2, grd * sdata[tid + blockDim.x * 2]);
+            atomicAdd(tIg + blockDim.x * 3, grd * sdata[tid + blockDim.x * 3]);
+            __syncthreads();
+        }
+    }
+}

--- a/crates/train-policy/src/model/select_affine/fwd.cu
+++ b/crates/train-policy/src/model/select_affine/fwd.cu
@@ -1,0 +1,68 @@
+#ifndef STUFF
+#define THREADS 512
+#define IN_SIZE 1024
+#endif
+
+constexpr int threads = THREADS;
+constexpr int in_size = IN_SIZE;
+
+extern "C" __global__ void kernel(
+    const float* weights,
+    const float* biases,
+    const float* input,
+    const int* moves,
+    float* output
+) {
+    extern __shared__ float sdata[]; 
+
+    const int batch_size = gridDim.y;
+    const int loc_in_batch = blockIdx.y;
+    const int loc_in_moves = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int locmb = loc_in_batch * 64 + loc_in_moves;
+    const int move = moves[locmb];
+
+    const float4* tW = reinterpret_cast<const float4*>(weights + in_size * move);
+    const float4* tI = reinterpret_cast<const float4*>(input + in_size * loc_in_batch);
+
+    if (move != -1)
+    {
+        float local = 0.0F;
+
+        #pragma unroll
+        for (int idx = tid; idx < in_size / 4; idx += threads)
+        {
+            const float4 tw = tW[idx];
+            const float4 ti = tI[idx];
+            local += tw.x * ti.x + tw.y * ti.y + tw.z * ti.z + tw.w * ti.w;
+        }
+
+        sdata[tid] = local;
+        __syncthreads();
+
+        if constexpr (threads >= 1024) { if (tid < 512) sdata[tid] += sdata[tid + 512]; __syncthreads(); }
+        if constexpr (threads >= 512) { if (tid < 256) sdata[tid] += sdata[tid + 256]; __syncthreads(); }
+        if constexpr (threads >= 256) { if (tid < 128) sdata[tid] += sdata[tid + 128]; __syncthreads(); }
+        if constexpr (threads >= 128) { if (tid < 64) sdata[tid] += sdata[tid + 64]; __syncthreads(); }
+
+        if (tid < 32)
+        {
+            float partial = sdata[tid];
+            if constexpr (threads >= 64) { partial += sdata[tid + 32]; }
+            partial += __shfl_down_sync(0xffffffff, partial, 16);
+            partial += __shfl_down_sync(0xffffffff, partial, 8);
+            partial += __shfl_down_sync(0xffffffff, partial, 4);
+            partial += __shfl_down_sync(0xffffffff, partial, 2);
+            partial += __shfl_down_sync(0xffffffff, partial, 1);
+
+            if (tid == 0)
+            {
+                output[locmb] = partial + biases[move];
+            }
+        }
+    }
+    else if (tid == 0)
+    {
+        output[locmb] = -10000.0F;
+    }
+}

--- a/crates/train-value/Cargo.toml
+++ b/crates/train-value/Cargo.toml
@@ -15,6 +15,6 @@ cuda = ["bullet_lib/cuda"]
 hip = ["bullet_lib/hip"]
 
 [dependencies]
-bullet_lib = { package = "bullet_lib", git = 'https://github.com/jw1912/bullet', default-features = false, rev = "36837b4788312dd123b59826230f357d12b68fd2" }
+bullet_lib = { package = "bullet_lib", git = 'https://github.com/jw1912/bullet', default-features = false, rev = "0891eca1fa3316db0d009df7146f85eab04407c2" }
 montyformat = { workspace = true }
-monty = { workspace = true, features = ["datagen"] }
+monty = { workspace = true }

--- a/src/networks/policy.rs
+++ b/src/networks/policy.rs
@@ -1,6 +1,6 @@
-mod inputs;
-mod outputs;
-mod see;
+pub mod inputs;
+pub mod outputs;
+pub mod see;
 
 use montyformat::chess::{Move, Position};
 
@@ -24,10 +24,12 @@ pub const L1: usize = 16384;
 #[cfg(feature = "datagen")]
 pub const L1: usize = 16384;
 
+pub const INPUT_SIZE: usize = 3072;
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PolicyNetwork {
-    l1: Layer<i8, { 768 * 4 }, L1>,
+    l1: Layer<i8, INPUT_SIZE, L1>,
     l2: TransposedLayer<i8, { L1 / 2 }, { outputs::NUM_MOVES_INDICES }>,
 }
 


### PR DESCRIPTION
Moves the policy trainer code into `crates/train-policy`.
The trainer can be run with `cargo r -r --package train-policy`. Requires CUDA.
The previously duplicated SEE code is now simply imported from `monty`.

No functional change.

Bench: 1124606