### PR TITLE
Improve Flipping

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -361,12 +361,15 @@ impl Tree {
         if clear_ptr && from_actions_ptr.half() == self.half.load(Ordering::Relaxed) {
             self[to].set_num_actions(0);
             to_actions.store(NodePtr::NULL);
+            self.tree[usize::from(to.half())].register_cross_link(to, NodePtr::NULL);
 
             self[from].set_num_actions(0);
             from_actions.store(NodePtr::NULL);
+            self.tree[usize::from(from.half())].register_cross_link(from, NodePtr::NULL);
         } else {
             self[to].set_num_actions(self[from].num_actions());
             to_actions.store(from_actions_ptr);
+            self.tree[usize::from(to.half())].register_cross_link(to, from_actions_ptr);
         }
     }
 
@@ -415,6 +418,7 @@ impl Tree {
             self.copy_across(first_child_ptr, num_children, new_ptr);
 
             most_recent_ptr.store(new_ptr);
+            self.tree[usize::from(parent_ptr.half())].register_cross_link(parent_ptr, new_ptr);
         }
 
         Some(())
@@ -526,6 +530,7 @@ impl Tree {
 
         actions_ptr.store(new_ptr);
         node.set_num_actions(count);
+        self.tree[self.half()].register_cross_link(node_ptr, new_ptr);
 
         Some(())
     }

--- a/src/tree/half.rs
+++ b/src/tree/half.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+    Mutex,
+};
 
 use super::{Node, NodePtr};
 use crate::chess::GameState;
@@ -11,6 +14,9 @@ pub struct TreeHalf {
     next: Vec<AtomicUsize>,
     end: Vec<AtomicUsize>,
     half: bool,
+    cross_links: Mutex<Vec<usize>>,
+    cross_link_marks: Vec<AtomicU64>,
+    cross_link_epoch: AtomicU64,
 }
 
 impl std::ops::Index<NodePtr> for TreeHalf {
@@ -23,12 +29,18 @@ impl std::ops::Index<NodePtr> for TreeHalf {
 
 impl TreeHalf {
     pub fn new(size: usize, half: bool, threads: usize) -> Self {
+        let cross_links = Mutex::new(Vec::new());
+        let cross_link_marks = (0..size).map(|_| AtomicU64::new(0)).collect();
+
         let mut res = Self {
             nodes: Vec::new(),
             used: AtomicUsize::new(0),
             next: (0..threads).map(|_| AtomicUsize::new(0)).collect(),
             end: (0..threads).map(|_| AtomicUsize::new(0)).collect(),
             half,
+            cross_links,
+            cross_link_marks,
+            cross_link_epoch: AtomicU64::new(1),
         };
 
         res.nodes.reserve_exact(size);
@@ -82,19 +94,47 @@ impl TreeHalf {
             n.store(0, Ordering::Relaxed);
             e.store(0, Ordering::Relaxed);
         }
+
+        self.cross_link_epoch.fetch_add(1, Ordering::Relaxed);
+        self.cross_links.lock().unwrap().clear();
     }
 
     pub fn clear_cross_links(&self, target_half: bool) {
-        let limit = self.used.load(Ordering::Relaxed).min(self.nodes.len());
+        let epoch = self.cross_link_epoch.load(Ordering::Relaxed);
+        let mut links = self.cross_links.lock().unwrap();
+        let mut idx = 0;
+        let mut to_clear = Vec::new();
 
-        for node in &self.nodes[..limit] {
-            let actions = node.actions();
-
-            if actions.is_null() || actions.half() != target_half {
+        while idx < links.len() {
+            let node_idx = links[idx];
+            if self.cross_link_marks[node_idx].load(Ordering::Relaxed) != epoch {
+                links.swap_remove(idx);
                 continue;
             }
 
-            node.clear_actions();
+            let node_ptr = NodePtr::new(self.half, node_idx);
+            let actions = self[node_ptr].actions();
+
+            if actions.is_null() || actions.half() == self.half {
+                self.cross_link_marks[node_idx].store(0, Ordering::Relaxed);
+                links.swap_remove(idx);
+                continue;
+            }
+
+            if actions.half() != target_half {
+                idx += 1;
+                continue;
+            }
+
+            self.cross_link_marks[node_idx].store(0, Ordering::Relaxed);
+            to_clear.push(node_ptr);
+            links.swap_remove(idx);
+        }
+
+        drop(links);
+
+        for node_ptr in to_clear {
+            self[node_ptr].clear_actions();
         }
     }
 
@@ -108,5 +148,19 @@ impl TreeHalf {
 
     pub fn is_full(&self) -> bool {
         self.used() >= self.nodes.len()
+    }
+    
+    pub fn register_cross_link(&self, node: NodePtr, target: NodePtr) {
+        debug_assert_eq!(node.half(), self.half);
+
+        if target.is_null() || target.half() == self.half {
+            self.cross_link_marks[node.idx()].store(0, Ordering::Relaxed);
+            return;
+        }
+
+        let epoch = self.cross_link_epoch.load(Ordering::Relaxed);
+        if self.cross_link_marks[node.idx()].swap(epoch, Ordering::Relaxed) != epoch {
+            self.cross_links.lock().unwrap().push(node.idx());
+        }
     }
 }

--- a/src/tree/half.rs
+++ b/src/tree/half.rs
@@ -149,7 +149,7 @@ impl TreeHalf {
     pub fn is_full(&self) -> bool {
         self.used() >= self.nodes.len()
     }
-    
+
     pub fn register_cross_link(&self, node: NodePtr, target: NodePtr) {
         debug_assert_eq!(node.half(), self.half);
 


### PR DESCRIPTION
At high threads and hash, this patch is a huge speed up and also prevent time losses. Adds cross-link tracking structures to TreeHalf, using an epoch-marked, mutex-protected list so cleanup only revisits nodes with cross-half references. Registers cross-links whenever the tree copies or retargets action pointers, ensuring stale cross-half children are cleaned up after flips.

Passed STC SMP:
LLR: 2.93 (-2.94,2.94) <-3.50,0.50>
Total: 4816 W: 1186 L: 1057 D: 2573
Ptnml(0-2): 32, 527, 1176, 626, 47
https://tests.montychess.org/tests/view/68f6f5106e68b500c1df7460

Bench: 1124606