### PR TITLE
Fix possible overusage of memory on hash allocation

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -264,8 +264,7 @@ fn setoption(
         if *x == "Threads" {
             *threads = y.parse().unwrap();
             let root = tree.root_position().clone();
-            *tree = Tree::new_mb(*hash_mb, *threads);
-            tree.set_root_position(&root);
+            tree.rebuild(*hash_mb, *threads, root);
             return;
         }
 
@@ -282,8 +281,7 @@ fn setoption(
     if name == "Hash" {
         *hash_mb = val as usize;
         let root = tree.root_position().clone();
-        *tree = Tree::new_mb(*hash_mb, *threads);
-        tree.set_root_position(&root);
+        tree.rebuild(*hash_mb, *threads, root);
     } else {
         params.set(name, val);
     }


### PR DESCRIPTION
When for example setting the thread count after the hash we temporarily used double the memory expected as the old tree was not deallocated first.

Recreate the tree with a new memory budget without overlapping the old allocation. Dropping the existing instance before building the new one prevents temporarily doubling the hash table's memory usage.

Passed STC Non-Reg:
LLR: 2.92 (-2.94,2.94) <-3.50,0.50>
Total: 38432 W: 10075 L: 10024 D: 18333
Ptnml(0-2): 520, 4401, 9359, 4380, 556
https://tests.montychess.org/tests/view/690dd4c26e68b500c1df7466

No functional change.

Bench: 1124606