### PR TITLE
Introduce Contempt

### DIFF
--- a/src/chess.rs
+++ b/src/chess.rs
@@ -82,7 +82,8 @@ impl EvalWdl {
         let mu = (a - b) / denom;
 
         // Correction factor: 16x
-        let delta_mu = (s * s * contempt * std::f32::consts::LN_10 / (400.0 * 16.0)).clamp(-8.0, 8.0);
+        let delta_mu =
+            (s * s * contempt * std::f32::consts::LN_10 / (400.0 * 16.0)).clamp(-8.0, 8.0);
         let mu_new = mu + delta_mu;
 
         let logistic = |x: f32| 1.0 / (1.0 + (-x).exp());

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -82,7 +82,7 @@ impl EvalWdl {
         let mu = (a - b) / denom;
 
         // Correction factor: 16x
-        let delta_mu = s * s * contempt * std::f32::consts::LN_10 / (400.0 * 16.0);
+        let delta_mu = (s * s * contempt * std::f32::consts::LN_10 / (400.0 * 16.0)).clamp(-8.0, 8.0);
         let mu_new = mu + delta_mu;
 
         let logistic = |x: f32| 1.0 / (1.0 + (-x).exp());

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,9 @@ mod net {
             return;
         }
 
-        uci::run(policy, value);
+        let tcec_mode = matches!(arg1.as_deref(), Some("tcec"));
+
+        uci::run(policy, value, tcec_mode);
     }
 }
 
@@ -269,6 +271,8 @@ mod nonet {
             return;
         }
 
-        uci::run(policy, value);
+        let tcec_mode = matches!(arg1.as_deref(), Some("tcec"));
+
+        uci::run(policy, value, tcec_mode);
     }
 }

--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -285,6 +285,7 @@ impl<'a> Searcher<'a> {
         let mut timer_last_output = Instant::now();
 
         let pos = self.tree.root_position();
+        let root_stm = pos.stm();
         let node = self.tree.root_node();
 
         // the root node is added to an empty tree, **and not counted** towards the
@@ -298,7 +299,7 @@ impl<'a> Searcher<'a> {
             self.tree
                 .expand_node(ptr, pos, self.params, self.policy, 1, 0);
 
-            let root_eval = pos.get_value_wdl(self.value, self.params);
+            let root_eval = pos.get_value_wdl(self.value, self.params, root_stm);
             self.tree.update_node_stats(ptr, 1.0 - root_eval, 0);
         }
         // relabel preexisting root policies with root PST value

--- a/src/mcts/iteration.rs
+++ b/src/mcts/iteration.rs
@@ -108,7 +108,11 @@ pub fn perform_one(
 
 fn get_utility(searcher: &Searcher, ptr: NodePtr, pos: &ChessState) -> f32 {
     match searcher.tree[ptr].state() {
-        GameState::Ongoing => pos.get_value_wdl(searcher.value, searcher.params),
+        GameState::Ongoing => pos.get_value_wdl(
+            searcher.value,
+            searcher.params,
+            searcher.tree.root_position().stm(),
+        ),
         GameState::Draw => 0.5,
         GameState::Lost(_) => 0.0,
         GameState::Won(_) => 1.0,

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -186,5 +186,5 @@ make_mcts_params! {
     min_policy_actions: i32 = 6, 1, 32, 1, 0.002;
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
-    contempt: i32 = 0, -1000, 1000, 10, 0.0;
+    contempt: i32 = 0, -1000, 1000, 10, 0.0; //Do not tune this value!
 }

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -186,5 +186,5 @@ make_mcts_params! {
     min_policy_actions: i32 = 6, 1, 32, 1, 0.002;
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
-    contempt: i32 = 0, -1000, 1000, 10, 0.0;
+    contempt: i32 = 0, -400, 400, 10, 0.0; //Do not tune this value!
 }

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -186,4 +186,5 @@ make_mcts_params! {
     min_policy_actions: i32 = 6, 1, 32, 1, 0.002;
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
+    contempt: i32 = 0, -1000, 1000, 10, 0.0;
 }

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -186,5 +186,5 @@ make_mcts_params! {
     min_policy_actions: i32 = 6, 1, 32, 1, 0.002;
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
-    contempt: i32 = 0, -1000, 1000, 10, 0.0;
+    contempt: i32 = 280, -1000, 1000, 10, 0.0;
 }

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -186,5 +186,5 @@ make_mcts_params! {
     min_policy_actions: i32 = 6, 1, 32, 1, 0.002;
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
-    contempt: i32 = 0, -400, 400, 10, 0.0; //Do not tune this value!
+    contempt: i32 = 0, -1000, 1000, 10, 0.0;
 }

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -186,5 +186,5 @@ make_mcts_params! {
     min_policy_actions: i32 = 6, 1, 32, 1, 0.002;
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
-    contempt: i32 = 280, -1000, 1000, 10, 0.0;
+    contempt: i32 = 0, -1000, 1000, 10, 0.0;
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -11,7 +11,7 @@ use std::{
     time::Instant,
 };
 
-pub fn run(policy: &PolicyNetwork, value: &ValueNetwork) {
+pub fn run(policy: &PolicyNetwork, value: &ValueNetwork, tcec_mode: bool) {
     let mut pos = ChessState::default();
     let mut root_game_ply = 0;
     let mut params = MctsParams::default();
@@ -143,7 +143,7 @@ pub fn run(policy: &PolicyNetwork, value: &ValueNetwork) {
             }
             "d" => pos.display(policy),
             "params" => params.list_spsa(),
-            "uci" => preamble(),
+            "uci" => preamble(tcec_mode),
             "ucinewgame" => {
                 root_game_ply = 0;
                 tree.clear(threads);
@@ -245,7 +245,7 @@ pub fn bench(depth: usize, policy: &PolicyNetwork, value: &ValueNetwork, params:
     );
 }
 
-fn preamble() {
+fn preamble(tcec_mode: bool) {
     println!("id name {}", env!("FORMATTED_NAME"));
     println!("id author Jamie Whiting, Viren & The Monty Authors");
     println!("option name Hash type spin default 64 min 1 max 524288");
@@ -254,8 +254,10 @@ fn preamble() {
     println!("option name MoveOverhead type spin default 400 min 0 max 5000");
     println!("option name report_moves type button");
     println!("option name report_iters type button");
-    println!("option name UCI_Opponent type string default");
-    println!("option name UCI_RatingAdv type spin default 0");
+    if tcec_mode {
+        println!("option name UCI_Opponent type string default");
+        println!("option name UCI_RatingAdv type spin default 0");
+    }
     println!("option name Contempt type spin default 0 min -1000 max 1000");
 
     #[cfg(feature = "tunable")]
@@ -408,7 +410,7 @@ fn apply_uci_contempt(
     opponent_rating: Option<i32>,
     rating_adv: Option<i32>,
 ) {
-    const DEFAULT_SELF_RATING: i32 = 3600;
+    const DEFAULT_SELF_RATING: i32 = 3550;
 
     let contempt = rating_adv.or_else(|| opponent_rating.map(|opp| DEFAULT_SELF_RATING - opp));
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -258,7 +258,7 @@ fn preamble(tcec_mode: bool) {
         println!("option name UCI_Opponent type string default");
         println!("option name UCI_RatingAdv type spin default 0");
     }
-    println!("option name Contempt type spin default 0 min -1000 max 1000");
+    println!("option name Contempt type spin default 0 min -400 max 400");
 
     #[cfg(feature = "tunable")]
     MctsParams::info(MctsParams::default());
@@ -318,7 +318,7 @@ fn setoption(
         "contempt" => {
             if let Some(v) = value {
                 if let Ok(parsed) = v.parse::<i32>() {
-                    let clamped = parsed.clamp(-1000, 1000);
+                    let clamped = parsed.clamp(-400, 400);
                     *contempt_override = Some(clamped);
                     params.set("contempt", clamped);
                     println!("info string using contempt {} elo", clamped);
@@ -415,7 +415,7 @@ fn apply_uci_contempt(
     let contempt = rating_adv.or_else(|| opponent_rating.map(|opp| DEFAULT_SELF_RATING - opp));
 
     if let Some(contempt) = contempt {
-        let clamped = contempt.clamp(-1000, 1000);
+        let clamped = contempt.clamp(-400, 400);
         params.set("contempt", clamped);
         println!("info string using contempt {} elo", clamped);
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -254,6 +254,8 @@ fn preamble() {
     println!("option name MoveOverhead type spin default 400 min 0 max 5000");
     println!("option name report_moves type button");
     println!("option name report_iters type button");
+    println!("option name UCI_Opponent type string default");
+    println!("option name UCI_RatingAdv type spin default 0");
     println!("option name Contempt type spin default 0 min -1000 max 1000");
 
     #[cfg(feature = "tunable")]

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -258,7 +258,7 @@ fn preamble(tcec_mode: bool) {
         println!("option name UCI_Opponent type string default");
         println!("option name UCI_RatingAdv type spin default 0");
     }
-    println!("option name Contempt type spin default 0 min -400 max 400");
+    println!("option name Contempt type spin default 0 min -1000 max 1000");
 
     #[cfg(feature = "tunable")]
     MctsParams::info(MctsParams::default());
@@ -318,7 +318,7 @@ fn setoption(
         "contempt" => {
             if let Some(v) = value {
                 if let Ok(parsed) = v.parse::<i32>() {
-                    let clamped = parsed.clamp(-400, 400);
+                    let clamped = parsed.clamp(-1000, 1000);
                     *contempt_override = Some(clamped);
                     params.set("contempt", clamped);
                     println!("info string using contempt {} elo", clamped);
@@ -415,7 +415,7 @@ fn apply_uci_contempt(
     let contempt = rating_adv.or_else(|| opponent_rating.map(|opp| DEFAULT_SELF_RATING - opp));
 
     if let Some(contempt) = contempt {
-        let clamped = contempt.clamp(-400, 400);
+        let clamped = contempt.clamp(-1000, 1000);
         params.set("contempt", clamped);
         println!("info string using contempt {} elo", clamped);
     }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -86,8 +86,26 @@ pub fn run(policy: &PolicyNetwork, value: &ValueNetwork) {
             "perft" => run_perft(&commands, &pos),
             "quit" => std::process::exit(0),
             "eval" => {
-                println!("cp: {}", pos.get_value(value, &params));
-                println!("wdl: {:.2}%", 100.0 * pos.get_value_wdl(value, &params));
+                let breakdown = pos.eval_with_contempt(value, &params, pos.stm());
+                println!("cp: {}", breakdown.cp);
+                println!(
+                    "wdl raw: {:.2}% {:.2}% {:.2}%",
+                    100.0 * breakdown.raw.win,
+                    100.0 * breakdown.raw.draw,
+                    100.0 * breakdown.raw.loss
+                );
+                println!(
+                    "wdl material: {:.2}% {:.2}% {:.2}%",
+                    100.0 * breakdown.material.win,
+                    100.0 * breakdown.material.draw,
+                    100.0 * breakdown.material.loss
+                );
+                println!(
+                    "wdl contempt: {:.2}% {:.2}% {:.2}%",
+                    100.0 * breakdown.contempt.win,
+                    100.0 * breakdown.contempt.draw,
+                    100.0 * breakdown.contempt.loss
+                );
             }
             "policy" => {
                 let mut max = f32::NEG_INFINITY;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -410,7 +410,7 @@ fn apply_uci_contempt(
     opponent_rating: Option<i32>,
     rating_adv: Option<i32>,
 ) {
-    const DEFAULT_SELF_RATING: i32 = 3550;
+    const DEFAULT_SELF_RATING: i32 = 3520;
 
     let contempt = rating_adv.or_else(|| opponent_rating.map(|opp| DEFAULT_SELF_RATING - opp));
 

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -254,7 +254,7 @@ fn preamble() {
     println!("option name MoveOverhead type spin default 400 min 0 max 5000");
     println!("option name report_moves type button");
     println!("option name report_iters type button");
-    println!("option name contempt type spin default 0 min -1000 max 1000");
+    println!("option name Contempt type spin default 0 min -1000 max 1000");
 
     #[cfg(feature = "tunable")]
     MctsParams::info(MctsParams::default());


### PR DESCRIPTION
Thanks to @Naphthalin for discussions about the theory of the contempt implementation.

Also implements UCI_Opponent/UCI_RatingAdv for TCEC adaptive contempt based on dynamic rating diff. These options are not exposed through UCI and depend on TCEC cutechess engine config being set to send them (m_sendOpponentsName/m_sendRatingAdv set to true).

Tests were conducted with 20s+0.2s 16MB hash vs 120s+1.2s 64MB hash.

Baseline:
```
Elo: 251.92 ± 3.8 (95%) LOS: 100.0%
Total: 20000 W: 12494 L: 93 D: 7413
Ptnml(0-2): 0, 17, 1364, 4820, 3799
nElo: 446.56 ± 8.0 (95%) PairsRatio: 507.00
```
https://tests.montychess.org/tests/view/691516ed0dbb0bf0dd726b36

Positive Contempt (+280 Elo):
```
Elo: 348.06 ± 5.1 (95%) LOS: 100.0%
Total: 20000 W: 15540 L: 293 D: 4167
Ptnml(0-2): 2, 42, 616, 3387, 5953
nElo: 592.12 ± 13.2 (95%) PairsRatio: 212.27
```
https://tests.montychess.org/tests/view/69151d630dbb0bf0dd726b43

Negative Contempt (-280 Elo):
```
Elo: -170.02 ± 2.8 (95%) LOS: 0.0%
Total: 20000 W: 41 L: 9115 D: 10844
Ptnml(0-2): 1754, 5577, 2658, 11, 0
nElo: -337.21 ± 5.9 (95%) PairsRatio: 0.00
```
https://tests.montychess.org/tests/view/691543130dbb0bf0dd726b4f

Additional tests were ran on 8 moves balanced book, at 120s+2s 8 threads for Monty and 30s+0.5s 8 threads for Viri 11:
```
Results of monty_contempt0 vs Viri-11 (120+2 - 30+0.5, 8t, 1000MB, 8moves_v3.pgn):
Elo: 69.71 +/- 11.69, nElo: 132.00 +/- 21.53
LOS: 100.00 %, DrawRatio: 47.40 %, PairsRatio: 4.60
Games: 1000, Wins: 277, Losses: 79, Draws: 644, Points: 599.0 (59.90 %)
Ptnml(0-2): [0, 47, 237, 187, 29], WL/DD Ratio: 0.16

Results of monty_contempt35 vs Viri-11 (120+2 - 30+0.5, 8t, 1000MB, 8moves_v3.pgn):
Elo: 86.15 +/- 12.00, nElo: 161.02 +/- 21.53
LOS: 100.00 %, DrawRatio: 44.80 %, PairsRatio: 6.89
Games: 1000, Wins: 300, Losses: 57, Draws: 643, Points: 621.5 (62.15 %)
Ptnml(0-2): [1, 34, 224, 203, 38], WL/DD Ratio: 0.10

Results of monty_contempt70 vs Viri-11 (120+2 - 30+0.5, 8t, 1000MB, 8moves_v3.pgn):
Elo: 86.89 +/- 11.39, nElo: 171.29 +/- 21.53
LOS: 100.00 %, DrawRatio: 47.00 %, PairsRatio: 8.81
Games: 1000, Wins: 295, Losses: 50, Draws: 655, Points: 622.5 (62.25 %)
Ptnml(0-2): [0, 27, 235, 204, 34], WL/DD Ratio: 0.11

Results of monty_contempt105 vs Viri-11 (120+2 - 30+0.5, 8t, 1000MB, 8moves_v3.pgn):
Elo: 84.67 +/- 12.45, nElo: 152.43 +/- 21.53
LOS: 100.00 %, DrawRatio: 41.80 %, PairsRatio: 5.47
Games: 1000, Wins: 315, Losses: 76, Draws: 609, Points: 619.5 (61.95 %)
Ptnml(0-2): [1, 44, 209, 207, 39], WL/DD Ratio: 0.17

Results of monty_contempt140 vs Viri-11 (120+2 - 30+0.5, 8t, 1000MB, 8moves_v3.pgn):
Elo: 75.52 +/- 11.61, nElo: 144.59 +/- 21.53
LOS: 100.00 %, DrawRatio: 48.00 %, PairsRatio: 5.67
Games: 1000, Wins: 280, Losses: 66, Draws: 654, Points: 607.0 (60.70 %)
Ptnml(0-2): [0, 39, 240, 189, 32], WL/DD Ratio: 0.13
```

The Elo loss of setting a contempt to +50 with a neutral opponent was measured:
UHO Lichess Book, STC:
https://tests.montychess.org/tests/view/691546bb0dbb0bf0dd726b56 (Neutral)
8 moves Balanced Book, STC:
https://tests.montychess.org/tests/view/6915c8b30dbb0bf0dd726b64 (Approx -4 Elo)

These show the contempt impl is robust to misalligned contempt values.

Passed Non-Reg STC (Contempt 0):
LLR: 3.04 (-2.94,2.94) <-3.50,0.50>
Total: 71648 W: 18853 L: 18880 D: 33915
Ptnml(0-2): 1079, 8442, 16853, 8327, 1123
https://tests.montychess.org/tests/view/691514240dbb0bf0dd726b33

Bench: 1158012