### PR TITLE
Introduce variance TM adjustment

### DIFF
--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -179,8 +179,16 @@ impl SearchHelpers {
                 * searcher.params.tm_bmv4())
         .clamp(searcher.params.tm_bmv5(), searcher.params.tm_bmv6());
 
-        let total_time =
-            (time as f32 * falling_eval * best_move_instability * best_move_visits) as u128;
+        let std_dev = searcher.tree[searcher.tree.root_node()].var().sqrt();
+        let variance_factor = (1.0
+            + (std_dev - searcher.params.tm_var_kt()) * searcher.params.tm_var_slope())
+        .clamp(searcher.params.tm_var_min(), searcher.params.tm_var_max());
+
+        let total_time = (time as f32
+            * falling_eval
+            * best_move_instability
+            * best_move_visits
+            * variance_factor) as u128;
 
         (elapsed >= total_time, score)
     }

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -187,4 +187,8 @@ make_mcts_params! {
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
     contempt: i32 = 0, -1000, 1000, 10, 0.0; //Do not tune this value!
+    tm_var_kt: f32 = 0.25, 0.0, 1.0, 0.025, 0.002;
+    tm_var_slope: f32 = 1.0, 0.0, 5.0, 0.1, 0.002;
+    tm_var_min: f32 = 0.5, 0.1, 1.0, 0.05, 0.002;
+    tm_var_max: f32 = 1.5, 1.0, 5.0, 0.15, 0.002;
 }


### PR DESCRIPTION
Passed STC:
LLR: 2.97 (-2.94,2.94) <0.00,4.00>
Total: 4768 W: 1335 L: 1165 D: 2268
Ptnml(0-2): 57, 505, 1119, 617, 86
https://tests.montychess.org/tests/view/6922d74895f4e6d12ae9eda0

Passed LTC:
LLR: 2.94 (-2.94,2.94) <0.00,4.00>
Total: 2304 W: 571 L: 427 D: 1306
Ptnml(0-2): 8, 215, 575, 333, 21
https://tests.montychess.org/tests/view/6922de7195f4e6d12ae9edab

bench 1158012