### PR TITLE
Revert "Introduce variance TM adjustment (#136)"

### DIFF
--- a/src/mcts/helpers.rs
+++ b/src/mcts/helpers.rs
@@ -179,16 +179,8 @@ impl SearchHelpers {
                 * searcher.params.tm_bmv4())
         .clamp(searcher.params.tm_bmv5(), searcher.params.tm_bmv6());
 
-        let std_dev = searcher.tree[searcher.tree.root_node()].var().sqrt();
-        let variance_factor = (1.0
-            + (std_dev - searcher.params.tm_var_kt()) * searcher.params.tm_var_slope())
-        .clamp(searcher.params.tm_var_min(), searcher.params.tm_var_max());
-
-        let total_time = (time as f32
-            * falling_eval
-            * best_move_instability
-            * best_move_visits
-            * variance_factor) as u128;
+        let total_time =
+            (time as f32 * falling_eval * best_move_instability * best_move_visits) as u128;
 
         (elapsed >= total_time, score)
     }

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -187,8 +187,4 @@ make_mcts_params! {
     visit_threshold_power: i32 = 3, 0, 8, 1, 0.002;
     virtual_loss_weight: f64 = 2.5, 1.0, 5.0, 0.25, 0.002;
     contempt: i32 = 0, -1000, 1000, 10, 0.0; //Do not tune this value!
-    tm_var_kt: f32 = 0.25, 0.0, 1.0, 0.025, 0.002;
-    tm_var_slope: f32 = 1.0, 0.0, 5.0, 0.1, 0.002;
-    tm_var_min: f32 = 0.5, 0.1, 1.0, 0.05, 0.002;
-    tm_var_max: f32 = 1.5, 1.0, 5.0, 0.15, 0.002;
 }


### PR DESCRIPTION
This reverts commit 52e06cbd24bab3ed07bdf269586d3333d2c27fcc. This patch antiscaled. Also, there was similar strange results, such as:

https://tests.montychess.org/tests/view/6923d97395f4e6d12ae9edcc (+80 STC)
https://tests.montychess.org/tests/view/6923e29095f4e6d12ae9edd9 (-10 VVLTC SMP)

Failing VVLTC SMP:
LLR: -1.76 (-2.94,2.94) <1.00,5.00>
Total: 3832 W: 743 L: 801 D: 2288
Ptnml(0-2): 1, 471, 1034, 405, 5
https://tests.montychess.org/tests/view/6925c89295f4e6d12ae9ee08

Bench: 1073577