### PR TITLE
Modify material scaling

### DIFF
--- a/src/chess.rs
+++ b/src/chess.rs
@@ -220,8 +220,10 @@ impl ChessState {
                 + self.piece_count(Piece::ROOK) * params.rook_value()
                 + self.piece_count(Piece::QUEEN) * params.queen_value();
 
-            let draw_adj =
-                raw.draw * (params.material_draw_offset() - mat) as f32 * params.material_draw_scale();
+            let draw_adj = raw.draw
+                * (params.material_draw_offset() - mat) as f32
+                * params.material_draw_scale()
+                / 1000.0;
 
             let sum = raw.win + raw.draw + draw_adj + raw.loss;
             let material = EvalWdl {

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -126,7 +126,7 @@ impl ChessState {
     pub const BENCH_DEPTH: usize = 4;
 
     #[cfg(not(feature = "datagen"))]
-    pub const BENCH_DEPTH: usize = 6;
+    pub const BENCH_DEPTH: usize = 5;
 
     pub fn board(&self) -> Position {
         self.board

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,19 +219,20 @@ mod net {
 
     pub fn run() {
         let mut args = std::env::args();
-        let arg1 = args.nth(1);
+        args.next();
+        let arg1 = args.next();
+        let arg2 = args.next();
 
         // Interpret the memory-mapped data as network structures
         let policy: &PolicyNetwork = unsafe { read_into_struct_unchecked(&NETWORKS.0) };
         let value: &ValueNetwork = unsafe { read_into_struct_unchecked(&NETWORKS.1) };
 
         if let Some("bench") = arg1.as_deref() {
-            uci::bench(
-                ChessState::BENCH_DEPTH,
-                policy,
-                value,
-                &MctsParams::default(),
-            );
+            let depth = arg2
+                .and_then(|d| d.parse().ok())
+                .unwrap_or(ChessState::BENCH_DEPTH);
+
+            uci::bench(depth, policy, value, &MctsParams::default());
             return;
         }
 
@@ -250,7 +251,9 @@ mod nonet {
 
     pub fn run() {
         let mut args = std::env::args();
-        let arg1 = args.nth(1);
+        args.next();
+        let arg1 = args.next();
+        let arg2 = args.next();
 
         let policy_mapped: MappedWeights<networks::PolicyNetwork> =
             unsafe { read_into_struct_unchecked(networks::PolicyFileDefaultName) };
@@ -262,12 +265,11 @@ mod nonet {
         let value = value_mapped.data;
 
         if let Some("bench") = arg1.as_deref() {
-            uci::bench(
-                ChessState::BENCH_DEPTH,
-                policy,
-                value,
-                &MctsParams::default(),
-            );
+            let depth = arg2
+                .and_then(|d| d.parse().ok())
+                .unwrap_or(ChessState::BENCH_DEPTH);
+
+            uci::bench(depth, policy, value, &MctsParams::default());
             return;
         }
 

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -131,7 +131,7 @@ macro_rules! make_mcts_params {
 
 make_mcts_params! {
     root_pst_adjustment: f32 = 0.34, 0.01, 1.0, 0.034, 0.002;
-    depth_pst_adjustment: f32 = 1.8, 0.1, 10.0, 0.018, 0.002;
+    depth_pst_adjustment: f32 = 1.8, 0.1, 10.0, 0.18, 0.002;
     winning_pst_threshold: f32 = 0.603, 0.0, 1.0, 0.05, 0.002;
     winning_pst_max: f32 = 1.615, 0.1, 10.0, 0.1, 0.002;
     base_pst_adjustment: f32 = 0.1, 0.01, 1.0, 0.01, 0.002;
@@ -152,8 +152,8 @@ make_mcts_params! {
     material_offset: i32 = 559, 400, 1200, 40, 0.002;
     material_div1: i32 = 36, 16, 64, 3, 0.002;
     material_div2: i32 = 1226, 512, 1536, 64, 0.002;
-    material_draw_offset: i32 = 15200, 0, 20000, 100, 0.002;
-    material_draw_scale: f32 = 0.000188, 0.0, 1.0, 0.00001, 0.002;
+    material_draw_offset: i32 = 15200, 0, 20000, 152, 0.002;
+    material_draw_scale: f32 = 0.188, 0.0, 1.0, 0.019, 0.002;
     tm_opt_value1: f64 = 0.64, 0.1, 1.2, 0.072, 0.002;
     tm_opt_value2: f64 = 0.434, 0.1, 1.0, 0.045, 0.002;
     tm_opt_value3: f64 = 0.66, 0.1, 1.2, 0.08, 0.002;

--- a/src/mcts/params.rs
+++ b/src/mcts/params.rs
@@ -152,6 +152,8 @@ make_mcts_params! {
     material_offset: i32 = 559, 400, 1200, 40, 0.002;
     material_div1: i32 = 36, 16, 64, 3, 0.002;
     material_div2: i32 = 1226, 512, 1536, 64, 0.002;
+    material_draw_offset: i32 = 15200, 0, 20000, 100, 0.002;
+    material_draw_scale: f32 = 0.000188, 0.0, 1.0, 0.00001, 0.002;
     tm_opt_value1: f64 = 0.64, 0.1, 1.2, 0.072, 0.002;
     tm_opt_value2: f64 = 0.434, 0.1, 1.0, 0.045, 0.002;
     tm_opt_value3: f64 = 0.66, 0.1, 1.2, 0.08, 0.002;


### PR DESCRIPTION
Thanks to @TomaszJaworski777 for the idea to try changing d directly. A script was used to find the optimal values to minimise the score difference to the current impl. This PR also reduces bench depth from 6 to 5, because the bench multiplied by 8, meaning it started taking too long. 

Failed STC:
LLR: -3.07 (-2.94,2.94) <0.00,4.00>
Total: 9536 W: 2479 L: 2608 D: 4449
Ptnml(0-2): 205, 1112, 2174, 1161, 116
https://tests.montychess.org/tests/view/693737f1893c51626ed63650

Passed LTC:
LLR: 3.04 (-2.94,2.94) <1.00,5.00>
Total: 6618 W: 1582 L: 1409 D: 3627
Ptnml(0-2): 48, 697, 1624, 914, 26
https://tests.montychess.org/tests/view/693738dd893c51626ed63656

Passed VVLTC SMP:
LLR: 2.96 (-2.94,2.94) <1.00,5.00>
Total: 2312 W: 524 L: 391 D: 1397
Ptnml(0-2): 0, 201, 621, 334, 0
https://tests.montychess.org/tests/view/69373f46893c51626ed63666

Bench: 467384