### PR TITLE
Fix comparator-ordering bug

### DIFF
--- a/src/mcts.rs
+++ b/src/mcts.rs
@@ -628,25 +628,32 @@ impl<'a> Searcher<'a> {
         let root = self.tree.root_node();
         let first_child_ptr = self.tree[root].actions();
 
-        let mut children: Vec<(NodePtr, Move)> = (0..self.tree[root].num_actions())
+        let mut children: Vec<(NodePtr, Move, f32)> = (0..self.tree[root].num_actions())
             .map(|action| {
                 let ptr = first_child_ptr + action;
-                (ptr, self.tree[ptr].parent_move())
+                (
+                    ptr,
+                    self.tree[ptr].parent_move(),
+                    Self::node_order_score(&self.tree[ptr]),
+                )
             })
             .collect();
 
-        children.sort_by(|(a_ptr, _), (b_ptr, _)| {
-            let a_score = Self::node_order_score(&self.tree[*a_ptr]);
-            let b_score = Self::node_order_score(&self.tree[*b_ptr]);
-
+        children.sort_by(|(a_ptr, _, a_score), (b_ptr, _, b_score)| {
+            // Keep comparisons deterministic by sorting on snapshot values only.
+            // Node statistics are updated concurrently during search and reading live
+            // values inside this comparator can violate sort's total-order contract.
             b_score
-                .partial_cmp(&a_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .total_cmp(a_score)
+                .then_with(|| a_ptr.idx().cmp(&b_ptr.idx()))
         });
 
         children.truncate(limit.min(children.len()));
 
         children
+            .into_iter()
+            .map(|(ptr, mov, _)| (ptr, mov))
+            .collect()
     }
 
     fn node_order_score(node: &Node) -> f32 {


### PR DESCRIPTION
The bug occurred when playing against a different opponent, because another opponent can sometimes play a less explored move. Passed 100 games vs a different opponent with no issues:

```
Results of MontyBugFix vs Minic (30+2, 384t, 48000MB, test_crashes.epd):
Elo: -59.64 +/- 33.91, nElo: -122.57 +/- 68.10
LOS: 0.02 %, DrawRatio: 54.00 %, PairsRatio: 0.21
Games: 100, Wins: 22, Losses: 39, Draws: 39, Points: 41.5 (41.50 %)
Ptnml(0-2): [2, 17, 27, 4, 0], WL/DD Ratio: 2.00
```

No functional change.
Bench: 1529336